### PR TITLE
Ensure that the version method returns the value as a string

### DIFF
--- a/src/BaseAsset.php
+++ b/src/BaseAsset.php
@@ -116,7 +116,7 @@ abstract class BaseAsset implements Asset
             return $version;
         }
 
-        return ! is_null($version) ? (string) $version : $version;
+        return $version === null ? null : (string) $version;
     }
 
     /**

--- a/src/BaseAsset.php
+++ b/src/BaseAsset.php
@@ -116,7 +116,7 @@ abstract class BaseAsset implements Asset
             return $version;
         }
 
-        return $version;
+        return ! is_null($version) ? (string) $version : $version;
     }
 
     /**


### PR DESCRIPTION
With version 2.2 a breaking change was introduced with the removal of type casting. It's a common use-case to set version the asset dynamically using the `filemtime` function, and that returns an `int`. Previously this did not result in a fatal error.