### PR TITLE
Fix assets initialized when they should not

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,12 @@
     "license": "GPL-2.0-or-later",
     "authors": [
         {
+            "name": "Inpsyde",
+            "email": "hello@inpsyde.com",
+            "homepage": "https://inpsyde.com",
+            "role": "Company"
+        },
+        {
             "name": "Christian Brückner",
             "email": "chris@chrico.info",
             "homepage": "https://www.chrico.info",
@@ -14,13 +20,15 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": ">=7.1"
+        "php": ">=7.1",
+        "ext-json": "*",
+        "inpsyde/wp-context": "^1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7",
-        "brain/monkey": "^2",
-        "mikey179/vfsstream": "~1.6",
-        "inpsyde/php-coding-standards": "1.*"
+        "phpunit/phpunit": "^7.5.20",
+        "brain/monkey": "^2.5.0",
+        "mikey179/vfsstream": "^1.6.8",
+        "inpsyde/php-coding-standards": "^1"
     },
     "autoload": {
         "psr-4": {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <ruleset name="Inpsyde Assets Standard">
 
-    <file>./inc</file>
+    <!-- Remove until #6 is merged <file>./inc</file> -->
     <file>./src</file>
     <file>./tests/phpunit/Unit</file>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,9 +1,47 @@
 <?xml version="1.0"?>
 <ruleset name="Inpsyde Assets Standard">
+
+    <file>./inc</file>
     <file>./src</file>
+    <file>./tests/phpunit/Unit</file>
+
+    <arg value="sp"/>
+    <arg name="colors"/>
+    <config name="testVersion" value="7.1-"/>
+    <config name="ignore_warnings_on_exit" value="1"/>
+
     <rule ref="Inpsyde"/>
 
     <rule ref="Inpsyde.CodeQuality.ArgumentTypeDeclaration.NoArgumentType">
-        <exclude-pattern>./src/Loader/*\.php</exclude-pattern>
+        <exclude-pattern>./src/**/*Interface\.php</exclude-pattern>
+        <exclude-pattern>./src/Asset\.php</exclude-pattern>
+    </rule>
+
+    <rule ref="Inpsyde.CodeQuality.Psr4">
+        <properties>
+            <property
+                name="psr4"
+                type="array"
+                value="Inpsyde\Assets=>src,Inpsyde\Assets\Tests=>tests/phpunit"/>
+        </properties>
+    </rule>
+
+    <!-- We expect inc/ files to both use and declare symbols -->
+    <rule ref="PSR1.Files.SideEffects.FoundWithSymbols">
+        <exclude-pattern>./inc</exclude-pattern>
+    </rule>
+
+    <!-- Relaxed checks for tests -->
+    <rule ref="WordPress.WP.EnqueuedResources">
+        <exclude-pattern>./tests</exclude-pattern>
+    </rule>
+    <rule ref="Inpsyde.CodeQuality.FunctionLength">
+        <exclude-pattern>./tests</exclude-pattern>
+    </rule>
+    <rule ref="Inpsyde.CodeQuality.ArgumentTypeDeclaration">
+        <exclude-pattern>./tests</exclude-pattern>
+    </rule>
+    <rule ref="Inpsyde.CodeQuality.ReturnTypeDeclaration">
+        <exclude-pattern>./tests</exclude-pattern>
     </rule>
 </ruleset>

--- a/src/Asset.php
+++ b/src/Asset.php
@@ -15,25 +15,29 @@ namespace Inpsyde\Assets;
 
 interface Asset
 {
-
-    // location types
+    // Location types
     public const FRONTEND = 2;
     public const BACKEND = 4;
     public const CUSTOMIZER = 8;
     public const LOGIN = 16;
     public const BLOCK_EDITOR_ASSETS = 32;
-    // hooks
+    public const BLOCK_ASSETS = 64;
+
+    // Hooks
     public const HOOK_FRONTEND = 'wp_enqueue_scripts';
     public const HOOK_BACKEND = 'admin_enqueue_scripts';
     public const HOOK_LOGIN = 'login_enqueue_scripts';
     public const HOOK_CUSTOMIZER = 'customize_controls_enqueue_scripts';
+    public const HOOK_BLOCK_ASSETS = 'enqueue_block_assets';
     public const HOOK_BLOCK_EDITOR_ASSETS = 'enqueue_block_editor_assets';
-    // Hooks are mapped to location types
+
+    // Hooks to Locations map
     public const HOOK_TO_LOCATION = [
         Asset::HOOK_FRONTEND => Asset::FRONTEND,
         Asset::HOOK_BACKEND => Asset::BACKEND,
         Asset::HOOK_LOGIN => Asset::LOGIN,
         Asset::HOOK_CUSTOMIZER => Asset::CUSTOMIZER,
+        Asset::HOOK_BLOCK_ASSETS => Asset::BLOCK_ASSETS,
         Asset::HOOK_BLOCK_EDITOR_ASSETS => Asset::BLOCK_EDITOR_ASSETS,
     ];
 
@@ -55,8 +59,7 @@ interface Asset
      * Define the full filePath to the Asset.
      *
      * @param string $filePath
-     *
-     * @return Asset
+     * @return static
      */
     public function withFilePath(string $filePath): Asset;
 
@@ -76,8 +79,7 @@ interface Asset
 
     /**
      * @param string ...$dependencies
-     *
-     * @return Script|Style
+     * @return static
      */
     public function withDependencies(string ...$dependencies): Asset;
 
@@ -90,26 +92,18 @@ interface Asset
 
     /**
      * @param string $version
-     *
-     * @return Asset|Script|Style
+     * @return static
      */
     public function withVersion(string $version): Asset;
 
     /**
-     *
-     * @return bool|callable
-     * @example     function() { return is_single(); }
-     *
-     * @example     'is_single'
+     * @return bool
      */
     public function enqueue(): bool;
 
     /**
      * @param bool|callable $enqueue
-     *
-     * @return Asset|Script|Style
-     *
-     * // phpcs:disable Inpsyde.CodeQuality.ArgumentTypeDeclaration.NoArgumentType
+     * @return static
      */
     public function canEnqueue($enqueue): Asset;
 
@@ -117,9 +111,9 @@ interface Asset
      * Location where the asset is enqueued.
      *
      * @return int
-     * @example     Asset::FRONTEND | Asset::BACKEND
      *
-     * @example     Asset::FRONTEND
+     * @example Asset::FRONTEND | Asset::BACKEND
+     * @example Asset::FRONTEND
      */
     public function location(): int;
 
@@ -127,22 +121,20 @@ interface Asset
      * Define a location based on Asset location types.
      *
      * @param int $location
-     *
-     * @return Asset|Script|Style
+     * @return static
      */
     public function forLocation(int $location): Asset;
 
     /**
      * A list of assigned output filters to change the rendered tag.
      *
-     * @return callable|OutputFilter\AssetOutputFilter[]
+     * @return array<callable|OutputFilter\AssetOutputFilter>
      */
     public function filters(): array;
 
     /**
-     * @param callable|OutputFilter\AssetOutputFilter ...$filters
-     *
-     * @return Asset|Script|Style
+     * @param callable|class-string<OutputFilter\AssetOutputFilter> ...$filters
+     * @return static
      */
     public function withFilters(...$filters): Asset;
 
@@ -155,8 +147,7 @@ interface Asset
 
     /**
      * @param string $handler
-     *
-     * @return Asset|Script|Style
+     * @return static
      */
     public function useHandler(string $handler): Asset;
 
@@ -166,13 +157,12 @@ interface Asset
     public function data(): array;
 
     /**
-     * Add a condtional tag for your Asset.
-     *
-     * @link https://developer.wordpress.org/reference/functions/wp_script_add_data/#comment-1007
+     * Add a conditional tag for your Asset.
      *
      * @param string $condition
+     * @return static
      *
-     * @return Asset|Script|Style
+     * @see https://developer.wordpress.org/reference/functions/wp_script_add_data/#comment-1007
      */
     public function withCondition(string $condition): Asset;
 }

--- a/src/Asset.php
+++ b/src/Asset.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Assets package.
  *

--- a/src/AssetFactory.php
+++ b/src/AssetFactory.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Assets package.
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
+declare(strict_types=1);
 
 namespace Inpsyde\Assets;
 

--- a/src/AssetHookResolver.php
+++ b/src/AssetHookResolver.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Assets package.
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
+declare(strict_types=1);
 
 namespace Inpsyde\Assets;
 

--- a/src/AssetManager.php
+++ b/src/AssetManager.php
@@ -133,8 +133,6 @@ final class AssetManager
             $found[$class][$handle] = $class;
 
             $this->assets->next();
-
-            $found = $asset;
         }
 
         return $found;

--- a/src/AssetManager.php
+++ b/src/AssetManager.php
@@ -188,7 +188,7 @@ final class AssetManager
         $hooksAdded = 0;
 
         /**
-         * Is is possible to execute AssetManager::setup() at a specific hook to only process assets
+         * It is possible to execute AssetManager::setup() at a specific hook to only process assets
          * specific of that hook.
          *
          * E.g. `add_action('enqueue_block_editor_assets', [new AssetManager, 'setup']);`

--- a/src/AssetManager.php
+++ b/src/AssetManager.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Assets package.
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
+declare(strict_types=1);
 
 namespace Inpsyde\Assets;
 

--- a/src/AssetManager.php
+++ b/src/AssetManager.php
@@ -113,7 +113,7 @@ final class AssetManager
     }
 
     /**
-     * @return array<Asset>
+     * @return array<string, array<string, Asset>>
      */
     public function assets(): array
     {
@@ -130,7 +130,7 @@ final class AssetManager
              */
             [$handle, $class] = $this->assets->getInfo();
             isset($found[$class]) or $found[$class] = [];
-            $found[$class][$handle] = $class;
+            $found[$class][$handle] = $asset;
 
             $this->assets->next();
         }

--- a/src/AssetManager.php
+++ b/src/AssetManager.php
@@ -252,14 +252,12 @@ final class AssetManager
         }
 
         $found = [];
-        $newAssets = $process ? new \SplObjectStorage() : null;
 
         $this->assets->rewind();
         while ($this->assets->valid()) {
 
             /** @var Asset $asset */
             $asset = $this->assets->current();
-            $info = $this->assets->getInfo();
             $this->assets->next();
 
             $handlerName = $asset->handler();
@@ -270,7 +268,6 @@ final class AssetManager
 
             $location = $asset->location();
             if (($location & $locationId) !== $locationId) {
-                $newAssets and $newAssets->attach($asset, $info);
                 continue;
             }
 
@@ -284,8 +281,6 @@ final class AssetManager
                 $handler->filter($asset);
             }
         }
-
-        $newAssets and $this->assets = $newAssets;
 
         return $found;
     }

--- a/src/AssetManager.php
+++ b/src/AssetManager.php
@@ -20,23 +20,23 @@ use Inpsyde\Assets\Handler\StyleHandler;
 
 final class AssetManager
 {
-
     public const ACTION_SETUP = 'inpsyde.assets.setup';
 
     /**
-     * Contains the state of the AssetManager to avoid booting the class twice.
+     * Contains the state of the AssetManager, where keys are hook names that are already added
+     * to avoid add them more than once.
      *
-     * @var bool
+     * @var array<string, bool>
      */
-    private $bootstrapped = false;
+    private $hooksAdded = [];
 
     /**
-     * @var Asset[]
+     * @var \SplObjectStorage<Asset, array{string, string}>
      */
-    private $assets = [];
+    private $assets;
 
     /**
-     * @var AssetHandler[]
+     * @var array<AssetHandler>
      */
     private $handlers = [];
 
@@ -46,25 +46,38 @@ final class AssetManager
     private $hookResolver;
 
     /**
-     * AssetManager constructor.
-     *
+     * @var bool
+     */
+    private $setupDone = false;
+
+    /**
      * @param AssetHookResolver|null $hookResolver
      */
     public function __construct(AssetHookResolver $hookResolver = null)
     {
         $this->hookResolver = $hookResolver ?? new AssetHookResolver();
+        $this->assets = new \SplObjectStorage();
     }
 
+    /**
+     * @return static
+     */
     public function useDefaultHandlers(): AssetManager
     {
-        $this->handlers = [
-            StyleHandler::class => new StyleHandler(wp_styles()),
-            ScriptHandler::class => new ScriptHandler(wp_scripts()),
-        ];
+        empty($this->handlers[StyleHandler::class])
+            and $this->handlers[StyleHandler::class] = new StyleHandler(wp_styles());
+
+        empty($this->handlers[ScriptHandler::class])
+            and $this->handlers[ScriptHandler::class] = new ScriptHandler(wp_scripts());
 
         return $this;
     }
 
+    /**
+     * @param string $name
+     * @param AssetHandler $handler
+     * @return static
+     */
     public function withHandler(string $name, AssetHandler $handler): AssetManager
     {
         $this->handlers[$name] = $handler;
@@ -73,133 +86,233 @@ final class AssetManager
     }
 
     /**
-     * @return AssetHandler[]
+     * @return array<AssetHandler>
      */
     public function handlers(): array
     {
         return $this->handlers;
     }
 
-    public function register(Asset ...$assets): AssetManager
+    /**
+     * @param Asset $asset
+     * @param Asset ...$assets
+     * @return static
+     */
+    public function register(Asset $asset, Asset ...$assets): AssetManager
     {
-        array_walk(
-            $assets,
-            function (Asset $asset) {
-                $class = get_class($asset);
-                $this->assets[$class][$asset->handle()] = $asset;
+        array_unshift($assets, $asset);
+
+        foreach ($assets as $asset) {
+            $handle = $asset->handle();
+            if ($handle) {
+                $this->assets->attach($asset, [$handle, get_class($asset)]);
             }
-        );
+        }
 
         return $this;
     }
 
     /**
-     * @return Asset[]
+     * @return array<Asset>
      */
     public function assets(): array
     {
-        return $this->assets;
+        $this->ensureSetup();
+
+        $found = [];
+        $this->assets->rewind();
+        while ($this->assets->valid()) {
+            /** @var Asset $asset */
+            $asset = $this->assets->current();
+            /**
+             * @var string $handle
+             * @var string $class
+             */
+            [$handle, $class] = $this->assets->getInfo();
+            isset($found[$class]) or $found[$class] = [];
+            $found[$class][$handle] = $class;
+
+            $this->assets->next();
+
+            $found = $asset;
+        }
+
+        return $found;
     }
 
     /**
-     * Retrieve an Asset instance by a given handle and type of Asset.
+     * Retrieve an `Asset` instance by a given asset handle and type (class).
+     *
+     * If the handle is unique by type, type can be omitted.
+     * It is possible to use a parent class as type.
+     * E.g an asset of a type `MyScript` that extends `Script` can be also retrieved passing
+     * either `MyScript or `Script` as type.
      *
      * @param string $handle
-     * @param string $type
-     *
+     * @param string|null $type
      * @return Asset|null
      */
-    public function asset(string $handle, string $type): ?Asset
+    public function asset(string $handle, ?string $type = null): ?Asset
     {
-        $asset = $this->assets[$type][$handle] ?? null;
+        $this->ensureSetup();
 
-        return $asset;
+        /** @var Asset|null $found */
+        $found = null;
+        $this->assets->rewind();
+
+        while ($this->assets->valid()) {
+            /** @var Asset $asset */
+            $asset = $this->assets->current();
+            $this->assets->next();
+
+            if (($asset->handle() !== $handle) || ($type && !is_a($asset, $type))) {
+                continue;
+            }
+
+            if ($found) {
+                // only one asset can match
+                return null;
+            }
+
+            $found = $asset;
+        }
+
+        return $found;
     }
 
     /**
-     * @wp-hook wp_enqueue_scripts
-     *
      * @return bool
-     *
-     * phpcs:disable Inpsyde.CodeQuality.NestingLevel
      */
     public function setup(): bool
     {
-        if ($this->bootstrapped) {
-            return false;
-        }
-        $this->bootstrapped = true;
+        $hooksAdded = 0;
 
-        $currentHooks = $this->hookResolver->resolve();
-        if (count($currentHooks) < 1) {
-            return false;
-        }
+        /**
+         * Is is possible to execute AssetManager::setup() at a specific hook to only process assets
+         * specific of that hook.
+         *
+         * E.g. `add_action('enqueue_block_editor_assets', [new AssetManager, 'setup']);`
+         *
+         * `$this->hookResolver->resolve()` will return current hook if it is one of the assets
+         * enqueuing hook.
+         */
+        foreach ($this->hookResolver->resolve() as $hook) {
+            // If the hook was already added, or it is in the past, don't bother adding.
+            if (!empty($this->hooksAdded[$hook]) || (did_action($hook) && !doing_action($hook))) {
+                continue;
+            }
 
-        foreach ($currentHooks as $currentHook) {
+            $hooksAdded++;
+            $this->hooksAdded[$hook] = true;
+
             add_action(
-                $currentHook,
-                function () use ($currentHook) {
-                    if (! did_action(self::ACTION_SETUP)) {
-                        $this->useDefaultHandlers();
-                        do_action(self::ACTION_SETUP, $this);
-                    }
-                    $this->processAssets($this->currentAssets($currentHook));
+                $hook,
+                function () use ($hook) {
+                    $this->processAssets($hook);
                 }
             );
         }
 
-        return true;
-    }
-
-    /**
-     * @param array $assets
-     */
-    private function processAssets(array $assets)
-    {
-        foreach ($assets as $asset) {
-            $handler = $this->handlers[$asset->handler()];
-
-            (! $asset->enqueue())
-                ? $handler->register($asset)
-                : $handler->enqueue($asset);
-
-            if ($handler instanceof OutputFilterAwareAssetHandler) {
-                $handler->filter($asset);
-            }
-        }
+        return $hooksAdded > 0;
     }
 
     /**
      * Returning all matching assets to given hook.
      *
      * @param string $currentHook
-     *
-     * @return Asset[]
-     *
-     * phpcs:disable Inpsyde.CodeQuality.NestingLevel
+     * @return array<Asset>
      */
     public function currentAssets(string $currentHook): array
     {
-        if (! isset(Asset::HOOK_TO_LOCATION[$currentHook])) {
+        return $this->loopCurrentHookAssets($currentHook, false);
+    }
+
+    /**
+     * @param string $currentHook
+     * @return void
+     */
+    private function processAssets(string $currentHook): void
+    {
+        $this->loopCurrentHookAssets($currentHook, true);
+    }
+
+    /**
+     * @param string $currentHook
+     * @param bool $process
+     * @return array<Asset>
+     */
+    private function loopCurrentHookAssets(string $currentHook, bool $process): array
+    {
+        $this->ensureSetup();
+        if (!$this->assets->count()) {
             return [];
         }
 
-        $currentAssets = [];
-        foreach ($this->assets as $type => $assets) {
-            /** @var Asset $asset */
-            foreach ($assets as $handle => $asset) {
-                $handler = $asset->handler();
-                if (! isset($this->handlers[$handler])) {
-                    continue;
-                }
+        $locationId = Asset::HOOK_TO_LOCATION[$currentHook] ?? null;
+        if (!$locationId) {
+            return [];
+        }
 
-                $location = $asset->location();
-                if ($location & Asset::HOOK_TO_LOCATION[$currentHook]) {
-                    $currentAssets[] = $asset;
-                }
+        $found = [];
+        $newAssets = $process ? new \SplObjectStorage() : null;
+
+        $this->assets->rewind();
+        while ($this->assets->valid()) {
+
+            /** @var Asset $asset */
+            $asset = $this->assets->current();
+            $info = $this->assets->getInfo();
+            $this->assets->next();
+
+            $handlerName = $asset->handler();
+            $handler = $handlerName ? ($this->handlers[$handlerName] ?? null) : null;
+            if (!$handler) {
+                continue;
+            }
+
+            $location = $asset->location();
+            if (($location & $locationId) !== $locationId) {
+                $newAssets and $newAssets->attach($asset, $info);
+                continue;
+            }
+
+            $found[] = $asset;
+            if (!$process) {
+                continue;
+            }
+
+            $done = $asset->enqueue() ? $handler->enqueue($asset) : $handler->register($asset);
+            if ($done && ($handler instanceof OutputFilterAwareAssetHandler)) {
+                $handler->filter($asset);
             }
         }
 
-        return $currentAssets;
+        $newAssets and $this->assets = $newAssets;
+
+        return $found;
+    }
+
+    /**
+     * @return void
+     */
+    private function ensureSetup(): void
+    {
+        if ($this->setupDone) {
+            return;
+        }
+
+        $this->setupDone = true;
+
+        $lastHook = $this->hookResolver->lastHook();
+
+        // We should not setup if there's no hook or last hook already fired.
+        if (!$lastHook && did_action($lastHook) && !doing_action($lastHook)) {
+            $this->assets = new \SplObjectStorage();
+
+            return;
+        }
+
+        $this->useDefaultHandlers();
+        do_action(self::ACTION_SETUP, $this);
     }
 }

--- a/src/ConfigureAutodiscoverVersionTrait.php
+++ b/src/ConfigureAutodiscoverVersionTrait.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Assets package.
  *
@@ -11,11 +9,12 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 namespace Inpsyde\Assets;
 
 trait ConfigureAutodiscoverVersionTrait
 {
-
     /**
      * Set to "false" and the version will not automatically discovered.
      *
@@ -29,10 +28,14 @@ trait ConfigureAutodiscoverVersionTrait
     /**
      * Enable automatic discovering of the version if no version is set.
      *
-     * @return self
+     * @return static
+     *
+     * phpcs:disable Inpsyde.CodeQuality.ReturnTypeDeclaration
      */
-    public function enableAutodiscoverVersion(): self
+    public function enableAutodiscoverVersion()
     {
+        // phpcs:enable Inpsyde.CodeQuality.ReturnTypeDeclaration
+
         $this->autodiscoverVersion = true;
 
         return $this;
@@ -41,10 +44,14 @@ trait ConfigureAutodiscoverVersionTrait
     /**
      * Disable automatic discovering of the version if no version is set.
      *
-     * @return self
+     * @return static
+     *
+     * phpcs:disable Inpsyde.CodeQuality.ReturnTypeDeclaration
      */
-    public function disableAutodiscoverVersion(): self
+    public function disableAutodiscoverVersion()
     {
+        // phpcs:enable Inpsyde.CodeQuality.ReturnTypeDeclaration
+
         $this->autodiscoverVersion = false;
 
         return $this;

--- a/src/Exception/FileNotFoundException.php
+++ b/src/Exception/FileNotFoundException.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Assets package.
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
+declare(strict_types=1);
 
 namespace Inpsyde\Assets\Exception;
 

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Assets package.
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
+declare(strict_types=1);
 
 namespace Inpsyde\Assets\Exception;
 

--- a/src/Exception/InvalidResourceException.php
+++ b/src/Exception/InvalidResourceException.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Assets package.
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
+declare(strict_types=1);
 
 namespace Inpsyde\Assets\Exception;
 

--- a/src/Exception/MissingArgumentException.php
+++ b/src/Exception/MissingArgumentException.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Assets package.
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
+declare(strict_types=1);
 
 namespace Inpsyde\Assets\Exception;
 

--- a/src/Handler/OutputFilterAwareAssetHandler.php
+++ b/src/Handler/OutputFilterAwareAssetHandler.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Assets package.
  *

--- a/src/Handler/OutputFilterAwareAssetHandlerTrait.php
+++ b/src/Handler/OutputFilterAwareAssetHandlerTrait.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Assets package.
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
+declare(strict_types=1);
 
 namespace Inpsyde\Assets\Handler;
 

--- a/src/Handler/ScriptHandler.php
+++ b/src/Handler/ScriptHandler.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Assets package.
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
+declare(strict_types=1);
 
 namespace Inpsyde\Assets\Handler;
 

--- a/src/Handler/StyleHandler.php
+++ b/src/Handler/StyleHandler.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Assets package.
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
+declare(strict_types=1);
 
 namespace Inpsyde\Assets\Handler;
 

--- a/src/Loader/ArrayLoader.php
+++ b/src/Loader/ArrayLoader.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Assets package.
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
+declare(strict_types=1);
 
 namespace Inpsyde\Assets\Loader;
 
@@ -26,10 +26,15 @@ class ArrayLoader implements LoaderInterface
     use ConfigureAutodiscoverVersionTrait;
 
     /**
-     * {@inheritDoc}
+     * @param mixed $data
+     * @return array
+     *
+     * phpcs:disable Inpsyde.CodeQuality.ArgumentTypeDeclaration
      */
     public function load($data): array
     {
+        // phpcs:enable Inpsyde.CodeQuality.ArgumentTypeDeclaration
+
         $assets = array_map(
             [AssetFactory::class, 'create'],
             (array) $data

--- a/src/Loader/EncoreEntrypointsLoader.php
+++ b/src/Loader/EncoreEntrypointsLoader.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Assets package.
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
+declare(strict_types=1);
 
 namespace Inpsyde\Assets\Loader;
 

--- a/src/Loader/PhpFileLoader.php
+++ b/src/Loader/PhpFileLoader.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Assets package.
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
+declare(strict_types=1);
 
 namespace Inpsyde\Assets\Loader;
 
@@ -20,15 +20,17 @@ use Inpsyde\Assets\Exception\FileNotFoundException;
  */
 class PhpFileLoader extends ArrayLoader
 {
-
     /**
-     * {@inheritDoc}
+     * @param mixed $resource
+     * @return array
      *
-     * @throws FileNotFoundException
+     * phpcs:disable Inpsyde.CodeQuality.ArgumentTypeDeclaration
      */
     public function load($resource): array
     {
-        if (! is_readable($resource)) {
+        // phpcs:enable Inpsyde.CodeQuality.ArgumentTypeDeclaration
+
+        if (!is_readable($resource)) {
             throw new FileNotFoundException(
                 sprintf(
                     'The given file "%s" does not exists or is not readable.',

--- a/src/Loader/WebpackManifestLoader.php
+++ b/src/Loader/WebpackManifestLoader.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Assets package.
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
+declare(strict_types=1);
 
 namespace Inpsyde\Assets\Loader;
 

--- a/src/OutputFilter/AsyncScriptOutputFilter.php
+++ b/src/OutputFilter/AsyncScriptOutputFilter.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Assets package.
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
+declare(strict_types=1);
 
 namespace Inpsyde\Assets\OutputFilter;
 

--- a/src/OutputFilter/AsyncStyleOutputFilter.php
+++ b/src/OutputFilter/AsyncStyleOutputFilter.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Assets package.
  *
@@ -11,35 +9,50 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 namespace Inpsyde\Assets\OutputFilter;
 
 use Inpsyde\Assets\Asset;
 
 class AsyncStyleOutputFilter implements AssetOutputFilter
 {
-
-    // phpcs:disable Inpsyde.CodeQuality.LineLength.TooLong
+    /**
+     * @var string
+     * phpcs:disable Inpsyde.CodeQuality.LineLength
+     */
     private $polyfill = '!function(t){"use strict";t.loadCSS||(t.loadCSS=function(){});var e=loadCSS.relpreload={};if(e.support=function(){var e;try{e=t.document.createElement("link").relList.supports("preload")}catch(t){e=!1}return function(){return e}}(),e.bindMediaToggle=function(t){var e=t.media||"all";function a(){t.media=e}t.addEventListener?t.addEventListener("load",a):t.attachEvent&&t.attachEvent("onload",a),setTimeout(function(){t.rel="stylesheet",t.media="only x"}),setTimeout(a,3e3)},e.poly=function(){if(!e.support())for(var a=t.document.getElementsByTagName("link"),n=0;n<a.length;n++){var o=a[n];"preload"!==o.rel||"style"!==o.getAttribute("as")||o.getAttribute("data-loadcss")||(o.setAttribute("data-loadcss",!0),e.bindMediaToggle(o))}},!e.support()){e.poly();var a=t.setInterval(e.poly,500);t.addEventListener?t.addEventListener("load",function(){e.poly(),t.clearInterval(a)}):t.attachEvent&&t.attachEvent("onload",function(){e.poly(),t.clearInterval(a)})}"undefined"!=typeof exports?exports.loadCSS=loadCSS:t.loadCSS=loadCSS}("undefined"!=typeof global?global:this);';
 
-    // phpcs:enable Inpsyde.CodeQuality.LineLength.TooLong
+    /**
+     * @var bool
+     * phpcs:enable Inpsyde.CodeQuality.LineLength
+     */
     private $polyfillPrinted = false;
 
+    /**
+     * @param string $html
+     * @param Asset $asset
+     * @return string
+     */
     public function __invoke(string $html, Asset $asset): string
     {
         $url = $asset->url();
         $version = $asset->version();
-        if ($version !== '') {
+        if ($version) {
             $url = add_query_arg('ver', $version, $url);
         }
 
-        $output = sprintf(
-            '<link rel="preload" href="%s" as="style" onload="this.onload=null;this.rel=\'stylesheet\'">',
-            esc_url($url)
-        );
-        $output .= '<noscript>' . $html . '</noscript>';
+        ob_start();
+        ?>
+        <link rel="preload" href="%s" as="style" onload="this.onload=null;this.rel='stylesheet'">
+        <noscript>%s</noscript>
+        <?php
+        $format = ob_get_clean();
 
-        if (! $this->polyfillPrinted) {
-            $output .= '<script>' . $this->polyfill . '</script>';
+        $output = sprintf($format, esc_url($url), $html);
+
+        if (!$this->polyfillPrinted) {
+            $output .= "<script>{$this->polyfill}</script>";
             $this->polyfillPrinted = true;
         }
 

--- a/src/OutputFilter/DeferScriptOutputFilter.php
+++ b/src/OutputFilter/DeferScriptOutputFilter.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Assets package.
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
+declare(strict_types=1);
 
 namespace Inpsyde\Assets\OutputFilter;
 

--- a/src/OutputFilter/InlineAssetOutputFilter.php
+++ b/src/OutputFilter/InlineAssetOutputFilter.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Assets package.
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
+declare(strict_types=1);
 
 namespace Inpsyde\Assets\OutputFilter;
 

--- a/src/Script.php
+++ b/src/Script.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Assets package.
  *
@@ -11,6 +9,8 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 namespace Inpsyde\Assets;
 
 use Inpsyde\Assets\Handler\ScriptHandler;
@@ -19,7 +19,6 @@ use Inpsyde\Assets\OutputFilter\DeferScriptOutputFilter;
 
 class Script extends BaseAsset implements Asset
 {
-
     /**
      * @return array
      */
@@ -42,30 +41,41 @@ class Script extends BaseAsset implements Asset
     /**
      * @param string $objectName
      * @param string|int|array|callable $data
+     * @return static
      *
-     * @return Script
-     * // phpcs:disable Inpsyde.CodeQuality.ArgumentTypeDeclaration.NoArgumentType
+     * phpcs:disable Inpsyde.CodeQuality.ArgumentTypeDeclaration
      */
-    public function withLocalize(string $objectName, $data): self
+    public function withLocalize(string $objectName, $data): Script
     {
+        // phpcs:enable Inpsyde.CodeQuality.ArgumentTypeDeclaration
+
         $this->config['localize'][$objectName] = $data;
 
         return $this;
     }
 
+    /**
+     * @return bool
+     */
     public function inFooter(): bool
     {
         return (bool) $this->config('inFooter', true);
     }
 
-    public function isInFooter(): self
+    /**
+     * @return static
+     */
+    public function isInFooter(): Script
     {
         $this->config['inFooter'] = true;
 
         return $this;
     }
 
-    public function isInHeader(): self
+    /**
+     * @return static
+     */
+    public function isInHeader(): Script
     {
         $this->config['inFooter'] = false;
 
@@ -82,10 +92,9 @@ class Script extends BaseAsset implements Asset
 
     /**
      * @param string $jsCode
-     *
-     * @return Script
+     * @return static
      */
-    public function prependInlineScript(string $jsCode): self
+    public function prependInlineScript(string $jsCode): Script
     {
         $this->config['inline']['before'][] = $jsCode;
 
@@ -94,22 +103,29 @@ class Script extends BaseAsset implements Asset
 
     /**
      * @param string $jsCode
-     *
-     * @return Script
+     * @return static
      */
-    public function appendInlineScript(string $jsCode): self
+    public function appendInlineScript(string $jsCode): Script
     {
         $this->config['inline']['after'][] = $jsCode;
 
         return $this;
     }
 
+    /**
+     * @return array
+     */
     public function translation(): array
     {
         return (array) $this->config('translation', []);
     }
 
-    public function withTranslation(string $domain = 'default', string $path = null): self
+    /**
+     * @param string $domain
+     * @param string|null $path
+     * @return static
+     */
+    public function withTranslation(string $domain = 'default', string $path = null): Script
     {
         $this->config['translation'] = ['domain' => $domain, 'path' => $path];
 
@@ -119,9 +135,9 @@ class Script extends BaseAsset implements Asset
     /**
      * Wrapper function to set AsyncScriptOutputFilter as filter.
      *
-     * @return Script
+     * @return static
      */
-    public function useAsyncFilter(): self
+    public function useAsyncFilter(): Script
     {
         return $this->withFilters(AsyncScriptOutputFilter::class);
     }
@@ -129,13 +145,16 @@ class Script extends BaseAsset implements Asset
     /**
      * Wrapper function to set DeferScriptOutputFilter as filter.
      *
-     * @return Script
+     * @return static
      */
-    public function useDeferFilter(): self
+    public function useDeferFilter(): Script
     {
         return $this->withFilters(DeferScriptOutputFilter::class);
     }
 
+    /**
+     * @return string
+     */
     protected function defaultHandler(): string
     {
         return ScriptHandler::class;

--- a/src/Style.php
+++ b/src/Style.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of the Assets package.
  *
@@ -11,6 +9,8 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 namespace Inpsyde\Assets;
 
 use Inpsyde\Assets\Handler\StyleHandler;
@@ -18,7 +18,6 @@ use Inpsyde\Assets\OutputFilter\AsyncStyleOutputFilter;
 
 class Style extends BaseAsset implements Asset
 {
-
     /**
      * @return string
      */
@@ -29,10 +28,9 @@ class Style extends BaseAsset implements Asset
 
     /**
      * @param string $media
-     *
-     * @return Style
+     * @return static
      */
-    public function forMedia(string $media): self
+    public function forMedia(string $media): Style
     {
         $this->config['media'] = $media;
 
@@ -48,13 +46,12 @@ class Style extends BaseAsset implements Asset
     }
 
     /**
-     * @link https://codex.wordpress.org/Function_Reference/wp_add_inline_style
-     *
      * @param string $inline
+     * @return static
      *
-     * @return Style
+     * @see https://codex.wordpress.org/Function_Reference/wp_add_inline_style
      */
-    public function withInlineStyles(string $inline): self
+    public function withInlineStyles(string $inline): Style
     {
         $this->config['inline'][] = $inline;
 
@@ -64,13 +61,16 @@ class Style extends BaseAsset implements Asset
     /**
      * Wrapper function to set AsyncStyleOutputFilter as filter.
      *
-     * @return Script
+     * @return static
      */
-    public function useAsyncFilter(): self
+    public function useAsyncFilter(): Style
     {
         return $this->withFilters(AsyncStyleOutputFilter::class);
     }
 
+    /**
+     * @return class-string<\Inpsyde\Assets\Handler\AssetHandler>
+     */
     protected function defaultHandler(): string
     {
         return StyleHandler::class;

--- a/tests/phpunit/Unit/AbstractTestCase.php
+++ b/tests/phpunit/Unit/AbstractTestCase.php
@@ -1,4 +1,15 @@
-<?php # -*- coding: utf-8 -*-
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Assets package.
+ *
+ * (c) Inpsyde GmbH
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 
 namespace Inpsyde\Assets\Tests\Unit;
 
@@ -13,7 +24,7 @@ abstract class AbstractTestCase extends TestCase
      *
      * @return void
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         Monkey\setUp();
@@ -24,7 +35,7 @@ abstract class AbstractTestCase extends TestCase
      *
      * @return void
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         Monkey\tearDown();
         parent::tearDown();

--- a/tests/phpunit/Unit/AssetFactoryTest.php
+++ b/tests/phpunit/Unit/AssetFactoryTest.php
@@ -1,9 +1,22 @@
 <?php
 
+declare(strict_types=1);
+
+/*
+ * This file is part of the Assets package.
+ *
+ * (c) Inpsyde GmbH
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Inpsyde\Assets\Tests\Unit;
 
 use Inpsyde\Assets\Asset;
 use Inpsyde\Assets\AssetFactory;
+use Inpsyde\Assets\Exception\InvalidArgumentException;
+use Inpsyde\Assets\Exception\MissingArgumentException;
 use Inpsyde\Assets\Script;
 use Inpsyde\Assets\Style;
 use org\bovigo\vfs\vfsStream;
@@ -11,25 +24,30 @@ use org\bovigo\vfs\vfsStreamDirectory;
 
 class AssetFactoryTest extends AbstractTestCase
 {
-
     /**
-     * @var  vfsStreamDirectory
+     * @var vfsStreamDirectory
      */
     private $root;
 
-    public function setUp()
+    /**
+     * @return void
+     */
+    public function setUp(): void
     {
         $this->root = vfsStream::setup('tmp');
         parent::setUp();
     }
 
-    public function testBasic()
+    /**
+     * @test
+     */
+    public function testBasic(): void
     {
         $expectedHandle = 'foo';
         $expectedType = Script::class;
         $expectedUrl = 'foo.js';
 
-        $testee = AssetFactory::create(
+        $factory = AssetFactory::create(
             [
                 'handle' => $expectedHandle,
                 'url' => $expectedUrl,
@@ -37,18 +55,21 @@ class AssetFactoryTest extends AbstractTestCase
             ]
         );
 
-        static::assertInstanceOf(Asset::class, $testee);
-        static::assertInstanceOf($expectedType, $testee);
-        static::assertSame($expectedUrl, $testee->url());
-        static::assertSame($expectedHandle, $testee->handle());
-        static::assertSame(Asset::FRONTEND, $testee->location());
+        static::assertInstanceOf(Script::class, $factory);
+        static::assertInstanceOf($expectedType, $factory);
+        static::assertSame($expectedUrl, $factory->url());
+        static::assertSame($expectedHandle, $factory->handle());
+        static::assertSame(Asset::FRONTEND, $factory->location());
     }
 
-    public function testCreateLocation()
+    /**
+     * @test
+     */
+    public function testCreateLocation(): void
     {
         $expectedLocation = Asset::BACKEND;
 
-        $testee = AssetFactory::create(
+        $factory = AssetFactory::create(
             [
                 'handle' => 'foo',
                 'location' => $expectedLocation,
@@ -57,13 +78,16 @@ class AssetFactoryTest extends AbstractTestCase
             ]
         );
 
-        static::assertSame($expectedLocation, $testee->location());
+        static::assertSame($expectedLocation, $factory->location());
     }
 
-    public function testCreateMultipleLocations()
+    /**
+     * @test
+     */
+    public function testCreateMultipleLocations(): void
     {
         $expected = Asset::FRONTEND | Asset::BACKEND | Asset::CUSTOMIZER;
-        $testee = AssetFactory::create(
+        $factory = AssetFactory::create(
             [
                 'handle' => 'foo',
                 'url' => 'foo.css',
@@ -72,44 +96,27 @@ class AssetFactoryTest extends AbstractTestCase
             ]
         );
 
-        static::assertSame($expected, $testee->location());
+        static::assertSame($expected, $factory->location());
     }
 
     /**
-     * @param array $config
-     *
+     * @test
      * @dataProvider provideInvalidConfig
-     *
-     * @expectedException \Inpsyde\Assets\Exception\MissingArgumentException
-     * @throws \Inpsyde\Assets\Exception\InvalidArgumentException
      */
-    public function testInvalidConfig(array $config)
+    public function testInvalidConfig(array $config): void
     {
+        $this->expectException(MissingArgumentException::class);
+
         AssetFactory::create($config);
     }
 
-    public function provideInvalidConfig()
-    {
-        yield 'missing type' => [
-            [
-                'handle' => 'foo',
-                'url' => 'foo.css',
-            ],
-        ];
-
-        yield 'missing url' => [
-            [
-                'handle' => 'foo',
-                'location' => Asset::FRONTEND,
-            ],
-        ];
-    }
-
     /**
-     * @expectedException  \Inpsyde\Assets\Exception\InvalidArgumentException
+     * @test
      */
-    public function testInvalidType()
+    public function testInvalidType(): void
     {
+        $this->expectException(InvalidArgumentException::class);
+
         AssetFactory::create(
             [
                 'handle' => 'foo',
@@ -121,10 +128,10 @@ class AssetFactoryTest extends AbstractTestCase
     }
 
     /**
-     * @throws \Throwable
+     * @test
      * @deprecated Loader\PhpArrayFileLoaderTest
      */
-    public function testCreateFromFile()
+    public function testCreateFromFile(): void
     {
         $content = <<<FILE
 <?php 
@@ -147,7 +154,6 @@ return [
     ],
 ];
 FILE;
-
         $filePath = vfsStream::newFile('config.php')
             ->withContent($content)
             ->at($this->root)
@@ -160,9 +166,10 @@ FILE;
     }
 
     /**
+     * @test
      * @deprecated Loader\PhpArrayLoaderTest
      */
-    public function testCreateFromArray()
+    public function testCreateFromArray(): void
     {
         $input = [
             [
@@ -183,5 +190,25 @@ FILE;
         static::assertCount(2, $assets);
         static::assertInstanceOf(Style::class, $assets[0]);
         static::assertInstanceOf(Script::class, $assets[1]);
+    }
+
+    /**
+     * @return \Generator
+     */
+    public function provideInvalidConfig(): \Generator
+    {
+        yield 'missing type' => [
+            [
+                'handle' => 'foo',
+                'url' => 'foo.css',
+            ],
+        ];
+
+        yield 'missing url' => [
+            [
+                'handle' => 'foo',
+                'location' => Asset::FRONTEND,
+            ],
+        ];
     }
 }

--- a/tests/phpunit/Unit/Loader/ArrayLoaderTest.php
+++ b/tests/phpunit/Unit/Loader/ArrayLoaderTest.php
@@ -1,4 +1,15 @@
-<?php declare(strict_types=1); # -*- coding: utf-8 -*-
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Assets package.
+ *
+ * (c) Inpsyde GmbH
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 
 namespace Inpsyde\Assets\Tests\Unit\Loader;
 

--- a/tests/phpunit/Unit/Loader/EncoreEntrypointsLoaderTest.php
+++ b/tests/phpunit/Unit/Loader/EncoreEntrypointsLoaderTest.php
@@ -1,4 +1,15 @@
-<?php declare(strict_types=1); # -*- coding: utf-8 -*-
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Assets package.
+ *
+ * (c) Inpsyde GmbH
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 
 namespace Inpsyde\Assets\Tests\Unit\Loader;
 
@@ -18,7 +29,7 @@ class EncoreEntrypointsLoaderTest extends AbstractTestCase
      */
     private $root;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->root = vfsStream::setup('tmp');
         parent::setUp();

--- a/tests/phpunit/Unit/Loader/PhpFileLoaderTest.php
+++ b/tests/phpunit/Unit/Loader/PhpFileLoaderTest.php
@@ -1,4 +1,15 @@
-<?php declare(strict_types=1); # -*- coding: utf-8 -*-
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Assets package.
+ *
+ * (c) Inpsyde GmbH
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 
 namespace Inpsyde\Assets\Tests\Unit\Loader;
 
@@ -17,7 +28,7 @@ class PhpFileLoaderTest extends AbstractTestCase
      */
     private $root;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->root = vfsStream::setup('tmp');
         parent::setUp();

--- a/tests/phpunit/Unit/OutputFilter/AsyncScriptOutputFilterTest.php
+++ b/tests/phpunit/Unit/OutputFilter/AsyncScriptOutputFilterTest.php
@@ -1,4 +1,15 @@
-<?php # -*- coding: utf-8 -*-
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Assets package.
+ *
+ * (c) Inpsyde GmbH
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 
 namespace Inpsyde\Assets\Tests\Unit\OutputFilter;
 

--- a/tests/phpunit/Unit/OutputFilter/AsyncStyleOutputFilterTest.php
+++ b/tests/phpunit/Unit/OutputFilter/AsyncStyleOutputFilterTest.php
@@ -1,4 +1,15 @@
-<?php # -*- coding: utf-8 -*-
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Assets package.
+ *
+ * (c) Inpsyde GmbH
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 
 namespace Inpsyde\Assets\Tests\Unit\OutputFilter;
 
@@ -21,7 +32,7 @@ class AsyncStyleOutputFilterTest extends AbstractTestCase
         $testee = new AsyncStyleOutputFilter();
 
         $expectedUrl = 'foo.jpg';
-        $input = '<link rel="stylesheet" url="'.$expectedUrl.'" />';
+        $input = '<link rel="stylesheet" url="' . $expectedUrl . '" />';
 
         Monkey\Functions\when('esc_url')->justReturn($expectedUrl);
         Monkey\Functions\when('esc_attr')->justReturn($expectedUrl);
@@ -32,7 +43,10 @@ class AsyncStyleOutputFilterTest extends AbstractTestCase
 
         $output = $testee($input, $stub);
 
-        static::assertContains('<link rel="preload" href="'.$expectedUrl.'" as="style"', $output);
+        static::assertContains(
+            '<link rel="preload" href="' . $expectedUrl . '" as="style"',
+            $output
+        );
         // is input wrapped into <noscript>-Tag?
         static::assertContains("<noscript>{$input}</noscript>", $output);
         // polyfill

--- a/tests/phpunit/Unit/OutputFilter/DeferScriptOutputFilterTest.php
+++ b/tests/phpunit/Unit/OutputFilter/DeferScriptOutputFilterTest.php
@@ -1,4 +1,15 @@
-<?php # -*- coding: utf-8 -*-
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Assets package.
+ *
+ * (c) Inpsyde GmbH
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 
 namespace Inpsyde\Assets\Tests\Unit\OutputFilter;
 

--- a/tests/phpunit/Unit/OutputFilter/InlineAssetOutputFilterTest.php
+++ b/tests/phpunit/Unit/OutputFilter/InlineAssetOutputFilterTest.php
@@ -1,4 +1,15 @@
-<?php # -*- coding: utf-8 -*-
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Assets package.
+ *
+ * (c) Inpsyde GmbH
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 
 namespace Inpsyde\Assets\Tests\Unit\OutputFilter;
 
@@ -40,7 +51,6 @@ class InlineAssetOutputFilterTest extends AbstractTestCase
         static::assertContains('data-version="' . $expectedVersion . '"', $result);
         static::assertContains('</style>', $result);
     }
-
 
     public function testRenderScript()
     {

--- a/tests/phpunit/Unit/StyleTest.php
+++ b/tests/phpunit/Unit/StyleTest.php
@@ -1,4 +1,15 @@
-<?php # -*- coding: utf-8 -*-
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Assets package.
+ *
+ * (c) Inpsyde GmbH
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 
 namespace Inpsyde\Assets\Tests\Unit;
 

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -1,19 +1,30 @@
-<?php # -*- coding: utf-8 -*-
+<?php
 
-putenv('TESTS_PATH='.__DIR__);
-putenv('LIBRARY_PATH='.dirname(__DIR__));
+declare(strict_types=1);
 
-$vendor = dirname(dirname(dirname(__FILE__))).'/vendor/';
+/*
+ * This file is part of the Assets package.
+ *
+ * (c) Inpsyde GmbH
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 
-if (! realpath($vendor)) {
+$libraryPath = dirname(__DIR__, 2);
+$vendorPath = "{$libraryPath}/vendor";
+if (!realpath($vendorPath)) {
     die('Please install via Composer before running tests.');
 }
 
-if (! defined('PHPUNIT_COMPOSER_INSTALL')) {
-    define('PHPUNIT_COMPOSER_INSTALL', $vendor.'autoload.php');
+putenv('LIBRARY_PATH=' . $libraryPath);
+putenv('FIXTURES_PATH=' . dirname(__DIR__) . '/fixtures');
+
+if (!defined('PHPUNIT_COMPOSER_INSTALL')) {
+    define('PHPUNIT_COMPOSER_INSTALL', "{$vendorPath}/autoload.php");
 }
 
-require_once $vendor.'/antecedent/patchwork/Patchwork.php';
-require_once $vendor.'autoload.php';
+require_once "{$vendorPath}/antecedent/patchwork/Patchwork.php";
+require_once "{$vendorPath}/autoload.php";
 
-unset($vendor);
+unset($libraryPath, $vendorPath);


### PR DESCRIPTION
See #8

- Introduce dependency to wp-context and use it to determine current context in AssetHookResolver
- Refactor assets manager to reduce looping and memory consumption
- Add location for 'enqueue_block_assets' which was missing
- Update tests accordingly
- Fix CS in src, inc, and tests
- Replace `self` as return type with class name, because `self` is problematic when extendig classes