### PR TITLE
Introduce the customizer preview init hook

### DIFF
--- a/src/Asset.php
+++ b/src/Asset.php
@@ -20,12 +20,14 @@ interface Asset
     public const LOGIN = 16;
     public const BLOCK_EDITOR_ASSETS = 32;
     public const BLOCK_ASSETS = 64;
+    public const CUSTOMIZER_PREVIEW = 128;
 
     // Hooks
     public const HOOK_FRONTEND = 'wp_enqueue_scripts';
     public const HOOK_BACKEND = 'admin_enqueue_scripts';
     public const HOOK_LOGIN = 'login_enqueue_scripts';
     public const HOOK_CUSTOMIZER = 'customize_controls_enqueue_scripts';
+    public const HOOK_CUSTOMIZER_PREVIEW = 'customize_preview_init';
     public const HOOK_BLOCK_ASSETS = 'enqueue_block_assets';
     public const HOOK_BLOCK_EDITOR_ASSETS = 'enqueue_block_editor_assets';
 
@@ -35,6 +37,7 @@ interface Asset
         Asset::HOOK_BACKEND => Asset::BACKEND,
         Asset::HOOK_LOGIN => Asset::LOGIN,
         Asset::HOOK_CUSTOMIZER => Asset::CUSTOMIZER,
+        Asset::HOOK_CUSTOMIZER_PREVIEW => Asset::CUSTOMIZER_PREVIEW,
         Asset::HOOK_BLOCK_ASSETS => Asset::BLOCK_ASSETS,
         Asset::HOOK_BLOCK_EDITOR_ASSETS => Asset::BLOCK_EDITOR_ASSETS,
     ];

--- a/src/AssetHookResolver.php
+++ b/src/AssetHookResolver.php
@@ -54,6 +54,7 @@ class AssetHookResolver
 
         if ($isFront) {
             $assets[] = Asset::HOOK_FRONTEND;
+            $assets[] = Asset::HOOK_CUSTOMIZER_PREVIEW;
 
             return $assets;
         }

--- a/src/Loader/AbstractWebpackLoader.php
+++ b/src/Loader/AbstractWebpackLoader.php
@@ -199,6 +199,10 @@ abstract class AbstractWebpackLoader implements LoaderInterface
             return Asset::LOGIN;
         }
 
+        if (stristr($fileName, '-customizer-preview')) {
+            return Asset::CUSTOMIZER_PREVIEW;
+        }
+
         if (stristr($fileName, '-customizer')) {
             return Asset::CUSTOMIZER;
         }

--- a/tests/phpunit/Unit/AssetHookResolverTest.php
+++ b/tests/phpunit/Unit/AssetHookResolverTest.php
@@ -66,7 +66,7 @@ class AssetHookResolverTest extends AbstractTestCase
         $hookResolver = new AssetHookResolver($context);
 
         static::assertSame(
-            [Asset::HOOK_BLOCK_ASSETS, Asset::HOOK_FRONTEND],
+            [Asset::HOOK_BLOCK_ASSETS, Asset::HOOK_FRONTEND, Asset::HOOK_CUSTOMIZER_PREVIEW],
             $hookResolver->resolve()
         );
     }


### PR DESCRIPTION
If merged this PR will introduce the possibility to enqueue scripts within the customizer preview context.

The existing Customizer hook does not allow to enqueue
scripts within the rendered preview which is happen in frontend.

The `customize_controls_enqueue_scripts` action is performed in admin context
but if we want to load scripts in the preview context, for instance to perform
UI updates of the site because a customize control change a setting value via
the transport postMessage, with the current implementation it's not possible because
the aforementioned hook is not fired in the customize preview context.

WordPress documentation show examples of using `customize_preview_init` hook
to enqueue scripts and infact that's the context in which we have to hook when we want
to perform stuffs in the front-office but only when it's the customizer preview context.

Since using the WebpackLoader to resolve the location automatically via the filename,
I've included a new condition in the loader class.