### PR TITLE
Missing case for DependencyExtractionPlugin json assets

### DIFF
--- a/src/Script.php
+++ b/src/Script.php
@@ -219,21 +219,28 @@ class Script extends BaseAsset implements Asset
      */
     protected function resolveDependencyExtractionPlugin(): bool
     {
-
         if ($this->resolvedDependencyExtractionPlugin) {
             return false;
         }
 
         $filePath = $this->filePath();
-        $depsPhpFile = str_replace(".js", ".assets.php", $filePath);
-        $depsJsonFile = str_replace(".js", ".assets.json", $filePath);
+        $depsPhpFile = str_replace(".js", ".asset.php", $filePath);
+        $depsPhpFileForCombinedAssets = str_replace(".js", ".assets.php", $filePath);
+        $depsJsonFile = str_replace(".js", ".asset.json", $filePath);
+        $depsJsonFileForCombinedAssets = str_replace(".js", ".assets.json", $filePath);
 
         $data = [];
+        // phpcs:disable WordPress.PHP.NoSilencedErrors.Discouraged
         if (file_exists($depsPhpFile)) {
-            $data = @require $depsPhpFile; // phpcs:ignore
+            $data = @require $depsPhpFile;
+        } elseif (file_exists($depsPhpFileForCombinedAssets)) {
+            $data = @json_decode(@file_get_contents($depsJsonFile), true);
         } elseif (file_exists($depsJsonFile)) {
-            $data = @json_decode(@file_get_contents($depsJsonFile), true); // phpcs:ignore
+            $data = @json_decode(@file_get_contents($depsJsonFile), true);
+        } elseif (file_exists($depsJsonFileForCombinedAssets)) {
+            $data = @json_decode(@file_get_contents($depsJsonFileForCombinedAssets), true);
         }
+        // phpcs:enable WordPress.PHP.NoSilencedErrors.Discouraged
 
         $dependencies = $data['dependencies'] ?? [];
         $version = $data['version'] ?? null;

--- a/src/Script.php
+++ b/src/Script.php
@@ -234,7 +234,7 @@ class Script extends BaseAsset implements Asset
         if (file_exists($depsPhpFile)) {
             $data = @require $depsPhpFile;
         } elseif (file_exists($depsPhpFileForCombinedAssets)) {
-            $data = @json_decode(@file_get_contents($depsJsonFile), true);
+            $data = @require $depsPhpFileForCombinedAssets;
         } elseif (file_exists($depsJsonFile)) {
             $data = @json_decode(@file_get_contents($depsJsonFile), true);
         } elseif (file_exists($depsJsonFileForCombinedAssets)) {

--- a/tests/phpunit/Unit/ScriptTest.php
+++ b/tests/phpunit/Unit/ScriptTest.php
@@ -280,15 +280,33 @@ class ScriptTest extends AbstractTestCase
         $expectedDependencies = ['foo', 'bar', 'baz'];
         $expectedVersion = '1.0';
 
-        yield 'json file' => [
+        yield 'json combined file' => [
             'script.assets.json',
             json_encode(['dependencies' => $expectedDependencies, 'version' => $expectedVersion]),
             $expectedDependencies,
             $expectedVersion,
         ];
 
-        yield 'php file' => [
+        yield 'json file' => [
+            'script.asset.json',
+            json_encode(['dependencies' => $expectedDependencies, 'version' => $expectedVersion]),
+            $expectedDependencies,
+            $expectedVersion,
+        ];
+
+        yield 'php combined file' => [
             'script.assets.php',
+            // phpcs:disable
+            '<?php return '
+            . var_export(['dependencies' => $expectedDependencies, 'version' => $expectedVersion], true)
+            . ';',
+            // phpcs:enable
+            $expectedDependencies,
+            $expectedVersion,
+        ];
+
+        yield 'php file' => [
+            'script.asset.php',
             // phpcs:disable
             '<?php return '
             . var_export(['dependencies' => $expectedDependencies, 'version' => $expectedVersion], true)


### PR DESCRIPTION
If merged this PR will give support to the WP DependencyExtractionPlugin 
even for non combined assets.

The WordPress DependencyExtractionPlugin can produce two different
files for the dependencies for both PHP and JSON.

By default the file suffix is `asset.php` or `asset.json`, but
in the case of the `combineAssets` option is given to the webpack plugin
the file name suffix becomes `assets.php` or `assets.json`.

I think this way to require the data extracted for the assets should be just a temporary solution.

There could be a more efficient way and consist of making use of the entry `json|php` within the `entrypoints.json` file.
It's can be an entry containing multiple data `json|php` files or just one in case the `combineAssets` is given to the webpack plugin.

Another thing to keep in mind is we probably have to address the use case when the `combinedOutputFile` is given as an option to the webpack plugin.

May be the other way could save some `file_exists` calls if the complexity is worth it.

For now the changes made in this pr will give support for the traditional use case of the webpack plugin e.g.

```
.addPlugin(new DependencyExtractionWebpackPlugin({
    outputFormat: 'json'
}))
```
