### PR TITLE
Block assets wont load in Back office

### DIFF
--- a/src/Loader/AbstractWebpackLoader.php
+++ b/src/Loader/AbstractWebpackLoader.php
@@ -192,6 +192,10 @@ abstract class AbstractWebpackLoader implements LoaderInterface
         }
 
         if (stristr($fileName, '-block')) {
+            return Asset::BLOCK_EDITOR_ASSETS | Asset::BLOCK_ASSETS;
+        }
+        
+        if (stristr($fileName, '-editor')) {
             return Asset::BLOCK_EDITOR_ASSETS;
         }
 


### PR DESCRIPTION
As a developer, I want to load the styles in the context of Gutenberg.

There are cases where I do not have only or just the editor style but also the frontend one for a block.
Right know there's not an autodiscover location for such case but should be.

This part is probably wrong, but the issue lie on the substring searched `-block`. 

```
if (stristr($fileName, '-block')) {
    return Asset::BLOCK_EDITOR_ASSETS | Asset::BLOCK_ASSETS;
}
```

This is because with the following fix `Asset::BLOCK_EDITOR_ASSETS | Asset::BLOCK_ASSETS;`  the asset required to load only on editor will load in front-office too. 
But without the right side value `Asset::BLOCK_ASSETS` the front-office style will not load within the Gutenberg Editor.

Therefore, would make sense to separate those two but then, we would use a more correct slug, `editor` for things to enqueue in the editor, `block` for things to load both, front-office and back-office.

This fix introduce a breaking change imo and I would like to discuss it a bit if it's possible to provide something which is backward compatible.