### PR TITLE
Add (Dequeueable?)ExternalAsset

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,7 @@
     "scripts": {
         "cs": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs",
         "tests": "@php ./vendor/phpunit/phpunit/phpunit",
+        "tests:xdebug": "@php -dxdebug.remote_enable=1 -dxdebug.mode=debug -dxdebug.start_with_request=1 -dzend_extension=xdebug.so ./vendor/phpunit/phpunit/phpunit --no-coverage",
         "tests:no-cov": "@php ./vendor/phpunit/phpunit/phpunit --no-coverage",
         "tests:codecov": "@php ./vendor/phpunit/phpunit/phpunit --coverage-clover coverage.xml",
         "qa": [

--- a/src/ExternalAsset.php
+++ b/src/ExternalAsset.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Assets package.
+ *
+ * (c) Inpsyde GmbH
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Inpsyde\Assets;
+
+use Inpsyde\Assets\Handler\ExternalAssetHandler;
+
+class ExternalAsset extends BaseAsset
+{
+    /** @noinspection MagicMethodsValidityInspection */
+    public function __construct(string $handle)
+    {
+        $this->handle = $handle;
+    }
+
+    /**
+     * @return string
+     */
+    protected function defaultHandler(): string
+    {
+        return ExternalAssetHandler::class;
+    }
+}

--- a/src/Handler/ExternalAssetHandler.php
+++ b/src/Handler/ExternalAssetHandler.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Assets package.
+ *
+ * (c) Inpsyde GmbH
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Inpsyde\Assets\Handler;
+
+use Inpsyde\Assets\Asset;
+
+interface ExternalAssetHandler
+{
+
+    /**
+     * @param Asset $asset
+     *
+     * @return bool
+     */
+    public function dequeue(Asset $asset): bool;
+}

--- a/src/Handler/ExternalScriptHandler.php
+++ b/src/Handler/ExternalScriptHandler.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Assets package.
+ *
+ * (c) Inpsyde GmbH
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Inpsyde\Assets\Handler;
+
+use Inpsyde\Assets\Asset;
+
+class ExternalScriptHandler implements ExternalAssetHandler
+{
+
+    /**
+     * @param Asset $asset
+     *
+     * @return bool
+     */
+    public function dequeue(Asset $asset): bool
+    {
+        if (! $asset->enqueue()) {
+            wp_dequeue_script($asset->handle());
+
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Handler/ExternalStyleHandler.php
+++ b/src/Handler/ExternalStyleHandler.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Assets package.
+ *
+ * (c) Inpsyde GmbH
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Inpsyde\Assets\Handler;
+
+use Inpsyde\Assets\Asset;
+
+class ExternalStyleHandler implements ExternalAssetHandler
+{
+
+    /**
+     * @param Asset $asset
+     *
+     * @return bool
+     */
+    public function dequeue(Asset $asset): bool
+    {
+        if (! $asset->enqueue()) {
+            wp_dequeue_style($asset->handle());
+
+            return true;
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

:arrow_up: not yet.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Looking to fix #19

I've done research on what I want happening vs what the current Assets APIs are, but could use some guidance from here on whether this PR direction is making architectural sense.


* **What is the current behavior?** (You can also link to an open issue here)

N/A


* **What is the new behavior (if this is a feature change)?**

I want to reach something like this

```php
$script = new ExternalScript( 'woocommerce' );
$script->canEnqueue( static fn(): bool => is_checkout() );
```

I want this to auto-dequeue external asset if `canEnqueue()` doesn't pass.

I still need to implement External{Script,Style}, but thought I'd post what I have at the moment.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Hopefully not.


* **Other information**:

What are your thoughts about how this idea is looking?