### PR TITLE
Fix dependencies when $config is an array

### DIFF
--- a/src/AssetFactory.php
+++ b/src/AssetFactory.php
@@ -86,7 +86,11 @@ final class AssetFactory
             if (!isset($config[$key])) {
                 continue;
             }
-            $asset->{$methodName}($config[$key]);
+            if ($key === 'dependencies') {
+                $asset->{$methodName}(...$config[$key]);
+            } else {
+                $asset->{$methodName}($config[$key]);
+            }
         }
 
         return $asset;

--- a/tests/phpunit/Unit/AssetFactoryTest.php
+++ b/tests/phpunit/Unit/AssetFactoryTest.php
@@ -46,12 +46,14 @@ class AssetFactoryTest extends AbstractTestCase
         $expectedHandle = 'foo';
         $expectedType = Script::class;
         $expectedUrl = 'foo.js';
+        $expectedDependencies = ['wp-blocks'];
 
         $factory = AssetFactory::create(
             [
                 'handle' => $expectedHandle,
                 'url' => $expectedUrl,
                 'type' => $expectedType,
+                'dependencies' => $expectedDependencies,
             ]
         );
 
@@ -60,6 +62,7 @@ class AssetFactoryTest extends AbstractTestCase
         static::assertSame($expectedUrl, $factory->url());
         static::assertSame($expectedHandle, $factory->handle());
         static::assertSame(Asset::FRONTEND, $factory->location());
+        static::assertSame($expectedDependencies, $factory->dependencies());
     }
 
     /**
@@ -134,7 +137,7 @@ class AssetFactoryTest extends AbstractTestCase
     public function testCreateFromFile(): void
     {
         $content = <<<FILE
-<?php 
+<?php
 use Inpsyde\Assets\Asset;
 use Inpsyde\Assets\Script;
 use Inpsyde\Assets\Style;


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

```php
AssetFactory::create([
    'url' => '/js/app.js',
    'handle' => 'app',
    'type' => Script::class,
    'dependencies' => ['wp-blocks'],
]);
```
Will trigger an error: `Argument 1 passed to Inpsyde\Assets\BaseAsset::withDependencies() must be of the type string, array given`

* **What is the new behavior (if this is a feature change)?**

None.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Nope.
