### PR TITLE
Set up GitHub Pages for documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,7 @@ When installed for development, via Composer, Inpsyde Assets also requires:
 
 ## Documentation
 
-1. [Getting started](docs/00-Getting%20started.md)
-2. [AssetFactory](docs/01-AssetFactory.md)
-3. [Loaders](docs/02-Loaders.md)
-4. [Assets](docs/03-Assets.md)
-5. [OutputFilter](docs/04-OutputFilter.md)
-6. [Helpers](docs/05-Helpers.md)
-7. [Migration](docs/99-Migration.md)
-
+Please reder to [/docs](./docs) or https://inpsyde.github.io/assets for information.
 
 ## License and Copyright
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-slate

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,10 @@
+_site
+.sass-cache
+.jekyll-cache
+.jekyll-metadata
+vendor
+
+Gemfile
+Gemfile.lock
+gems.rb
+gems.locked

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,33 @@
+---
+title: Home
+nav_order: 0
+permalink: /
+---
+
+# Inpsyde Assets
+
+## Introduction
+Inpsyde Assets is a Composer package (not a plugin) that allows to deal with scripts and styles in a WordPress site.
+
+## Installation
+
+```bash
+$ composer require inpsyde/assets
+```
+
+## Minimum Requirements and Dependencies
+
+* PHP 7.2+
+* WordPress latest-2
+
+When installed for development, via Composer, Inpsyde Assets also requires:
+
+* phpunit/phpunit (BSD-3-Clause)
+* brain/monkey (MIT)
+* inpsyde/php-coding-standards
+
+## License and Copyright
+
+Copyright (c) Inpsyde GmbH.
+
+The team at [Inpsyde](https://inpsyde.com) is engineering the Web since 2006.

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,39 @@
+title: Inpsyde Assets
+description: >-
+  Inpsyde Assets is a Composer package (not a plugin) that allows to deal with scripts and styles in a WordPress site.
+baseurl: /assets # Your repo name with a leading slash.
+
+# Aux links for the upper right navigation
+aux_links:
+  "Inpsyde Assets on GitHub":
+    - https://github.com/inpsyde/assets
+
+# Footer "Edit this page on GitHub" link text
+gh_edit_repository: https://github.com/inpsyde/assets # Your repo GitHub URL
+
+# Everything above is repo specific.
+
+###############################################################
+
+# This section is repo specific. These can be omitted if defaults make sense.
+
+gh_edit_branch: master # The default branch of the repo. Default: main
+gh_edit_source: docs # The directory containing the docs. Default: docs
+
+###############################################################
+
+# Everything below should be copy and pasted into package repos
+remote_theme: inpsyde/jekyll-inpsyde-theme
+
+###############################################################
+
+# Everything below should be copy and pasted into package repos
+# To be replaced by jekyll-inpsyde-theme's `_config.yml` when GitHub Pages supports Jekyll v4.
+
+plugins:
+  - jekyll-remote-theme
+  - jekyll-seo-tag
+  - jekyll-sitemap
+  - jemoji
+
+permalink: pretty

--- a/docs/asset-factory.md
+++ b/docs/asset-factory.md
@@ -1,7 +1,18 @@
-# `AssetFactory`
+---
+nav_order: 2
+---
+# Asset Factory
+{: .no_toc }
+## Table of contents
+{: .no_toc .text-delta }
+1. TOC
+{:toc}
+---
+
+## `AssetFactory`
 Instead of creating instances by hand, it's sometimes easier to use configuration via array or file to manage your specific assets.
 
-**[!] Note:** The `AssetFactory` is currently replaced step by step via Loaders. Methods are set to `@deprecated` which have been moved to a Loader.
+**:warning: Note:** The `AssetFactory` is currently replaced step by step via Loaders. Methods are set to `@deprecated` which have been moved to a Loader.
 
 ## `AssetFactory::create()`
 

--- a/docs/assets.md
+++ b/docs/assets.md
@@ -1,4 +1,13 @@
+---
+nav_order: 4
+---
 # Assets
+{: .no_toc }
+## Table of contents
+{: .no_toc .text-delta }
+1. TOC
+{:toc}
+---
 
 There are two main classes delivered:
 
@@ -88,7 +97,7 @@ By default, the package comes with predefined locations of assets:
 |const|hook|location|
 |---|---|---|
 |`Asset::FRONTEND`|`wp_enqueue_scripts`|Frontend|
-|`Asset::BACKEND`|`admin_enqueue_scripts`|Backend| 
+|`Asset::BACKEND`|`admin_enqueue_scripts`|Backend|
 |`Asset::LOGIN`|`login_enqueue_scripts`|wp-login.php|
 |`Asset::CUSTOMIZER`|`customize_controls_enqueue_scripts`|Customizer|
 |`Asset::CUSTOMIZER_PREVIEW`|`customize_preview_init`|Customizer Preview|
@@ -128,14 +137,14 @@ use Inpsyde\Assets\AssetManager;
 use Inpsyde\Assets\Style;
 use Inpsyde\Assets\Asset;
 
-add_action( 
-    AssetManager::ACTION_SETUP, 
+add_action(
+    AssetManager::ACTION_SETUP,
     function(AssetManager $assetManager) {
         $style = new Style('foo', 'www.example.com/style.css', Asset::BACKEND | Asset::FRONTEND );
         // or
         $style = new Style('foo', 'www.example.com/style.css');
         $style->forLocation(Asset::BACKEND | Asset::FRONTEND);
-        
+
         $assetManager->register($style);
     }
 );
@@ -178,7 +187,7 @@ following:
     ],
     "version": "1234567"
 }
-``` 
+```
 
 ```php
 <?php
@@ -198,17 +207,17 @@ $script->version();        // "1234567"
 Based on your `Asset::filePath` the `Script` automatically searches in the same folder for `{fileName}.assets.json|php`
 and will load the data.
 
-**[!]** This will not overwrite your existing settings:
+:warning: This will not overwrite your existing settings:
 
 **script.assets.php**
 
 ```php
 <?php
 return [
-    "dependencies" => ["foo", "bar", "baz"], 
+    "dependencies" => ["foo", "bar", "baz"],
     "version" => "1234567"
 ];
-``` 
+```
 
 ```php
 <?php
@@ -384,7 +393,7 @@ $script->withAttributes(
         'nonce' => wp_create_nonce()
     ]
 );
-// <script src="script.js" id="my-handle-js" async data-value="key" nonce="{generated nonce}"></script> 
+// <script src="script.js" id="my-handle-js" async data-value="key" nonce="{generated nonce}"></script>
 
 
 $style = new Style('my-handle', 'style.css');
@@ -394,7 +403,7 @@ $style->withAttributes(
         'nonce' => wp_create_nonce()
     ]
 );
-// <link rel="stylesheet" href="style.css" id="my-handle-css" data-value="key" nonce="{generated nonce}" /> 
+// <link rel="stylesheet" href="style.css" id="my-handle-css" data-value="key" nonce="{generated nonce}" />
 ```
 
 Existing attributes like "src" or "id" are not overwriteable. The `Inpsyde\Assets\OutputFilter\AttributesOutputFilter` only sets attributes which are not already existent on the html-tag. This will *not* work:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,4 +1,11 @@
-# Getting started - the `AssetManager`
+---
+nav_order: 1
+---
+
+# Getting started
+
+## Getting started - the `AssetManager`
+
 When using Assets in your theme or plugin, you can simply access the `Inpsyde\Assets\AssetManager` by hooking into the setup-hook.
 
 This way you can start registering your assets:
@@ -11,10 +18,10 @@ use Inpsyde\Assets\Style;
 use Inpsyde\Assets\Asset;
 
 
-add_action( 
-	AssetManager::ACTION_SETUP, 
+add_action(
+	AssetManager::ACTION_SETUP,
 	function(AssetManager $assetManager) {
-	
+
 		$assetManager->register(
 			new Script('foo', 'www.example.com/script.js'),
 			new Style('foo', 'www.example.com/style.css')

--- a/docs/helpers.md
+++ b/docs/helpers.md
@@ -1,4 +1,14 @@
+---
+nav_order: 6
+---
 # Helpers
+{: .no_toc }
+## Table of contents
+{: .no_toc .text-delta }
+1. TOC
+{:toc}
+---
+
 
 The `inpsyde/assets`-Package comes with some useful helper functions.
 
@@ -14,8 +24,8 @@ use function Inpsyde\Assets\withAssetSuffix;
 $fileName = withAssetSuffix('my-script.js');
 
 // if SCRIPT_DEBUG === false -> my-script.min.js
-// if SCRIPT_DEBUG === true -> my-script.js 
-``` 
+// if SCRIPT_DEBUG === true -> my-script.js
+```
 
 
 ## Symlink an Asset-folder

--- a/docs/loaders.md
+++ b/docs/loaders.md
@@ -1,4 +1,13 @@
+---
+nav_order: 3
+---
 # Loaders
+{: .no_toc }
+## Table of contents
+{: .no_toc .text-delta }
+1. TOC
+{:toc}
+---
 
 ## WebpackLoaders
 Webpack is a module bundler. Its main purpose is to bundle JavaScript files for usage in a browser, yet it is also capable of transforming, bundling, or packaging just about any resource or asset.
@@ -63,7 +72,7 @@ The `EncoreEntrypointsLoader` can load those configurations and automatically co
         }
      }
 }
-``` 
+```
 
 And loading this file:
 
@@ -139,7 +148,7 @@ return [
 		'type' => Script::class
     ],
 ];
-``` 
+```
 
 And in your application:
 
@@ -168,4 +177,4 @@ $loader->disableAutodiscoverVersion();
 $assets = $loader->load('manifest.json');
 ```
 
-**[!]** All 4 loaders supporting to disable the auto discovering of version.
+:warning: All 4 loaders supporting to disable the auto discovering of version.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,4 +1,13 @@
+---
+nav_order: 7
+---
 # Migration
+{: .no_toc }
+## Table of contents
+{: .no_toc .text-delta }
+1. TOC
+{:toc}
+---
 
 ## From 1.0 to 1.1
 In version 1.1 we didn't implemented breaking changes, but we're renamend some internals for `Inpsyde\Assets\Asset` to be more clear when using the config-driven approach. In future you'll have to change your Asset-configuration, since we don't want to ship to much legacy code.
@@ -42,6 +51,7 @@ AssetFactory::create(
 
 ## From 0.2 to 1.0
 ### Asset registration
+{: .no_toc }
 In version 1.0 the function `Inpsyde\Assets\assetManager()` was replaced to improve the compatilibty with WordPress and to avoid calling `wp_styles()` and `wp_scripts()` too early. This is why the registration of an `Asset` now happens via hook callback instead of using the factory-function.
 
 **Before:**
@@ -67,6 +77,7 @@ add_action(
 ```
 
 ### Renaming of `Asset`-flags and `AssetFactory::create` requirements
+{: .no_toc }
 The type-flags from `Inpsyde\Assets\Asset` are renamed after the location where the given asset will be enqueued. Also the `type` is now no longer used to create instances of the class. Instead the class itself should be defined in `'class'`-field of the `$config` when using the `AssetFactory`.
 
 This enables also the possiblity to use different implementations of `Inpsyde\Assets\Asset` with own `INpsyde\Assets\Handler\AssetHandler`.

--- a/docs/output-filter.md
+++ b/docs/output-filter.md
@@ -1,4 +1,18 @@
-# `OutputFilter`
+---
+nav_order: 5
+---
+# Output Filter
+{: .no_toc }
+## Table of contents
+{: .no_toc .text-delta }
+1. TOC
+{:toc}
+---
+
+## Output Filter
+
+### `OutputFilter`
+{: .no_toc }
 
 These callbacks are specified to manipulate the output of the `Script` via `script_loader_tag` and `Style`
 via `style_loader_tag`.
@@ -20,34 +34,34 @@ $script = $script->withFilters(AsyncScriptOutputFilter::class);
 Following default OutputFilters are shipped with this package:
 
 ### `AsyncStyleOutputFilter`
-
+{: .no_toc }
 This filter will allow you to load your CSS async via `preload`. It also delivers a polyfill for older browsers which is
 appended once to ensure that script-loading works properly.
 
-```
+```html
 <link rel="preload" href="{url}" as="style" onload="this.onload=null;this.rel='stylesheet'">
 <noscript><link rel="stylesheet" href="{url}" /></noscript>
 <script>/* polyfill for older browsers */</script>
 ```
 
 ### `InlineAssetOutputFilter`
-
+{: .no_toc }
 This filter allows you to print your `Style` or `Script` inline into the DOM if the file is readable.
 
 ### `AttributesOutputFilter`
-
+{: .no_toc }
 This filter will be added automatically if you're using `Asset::withAttributes([])` and allows you to set additonal
 key-value pairs as attributes to your `script`- or `link`-tag.
 
-See more in [03 - Assets.md](./03 - Assets.md).
+See more in [Assets](./assets.md).
 
 ### `AsyncScriptOutputFilter` (deprecated)
-
-**[!] deprecated:** Please use instead `Script::withAttributes(['async' => true]);`
+{: .no_toc }
+:warning: **Deprecated:** Please use instead `Script::withAttributes(['async' => true]);`
 
 ### `DeferScriptOutputFilter`  (deprecated)
-
-**[!] deprecated:** Please use instead `Script::withAttributes(['defer' => true]);`
+{: .no_toc }
+:warning: **Deprecated:** Please use instead `Script::withAttributes(['defer' => true]);`
 
 ## Create your own filter
 


### PR DESCRIPTION
Attempt to make jekyll works on GitHub.

TODOs:

- [ ] [Domain mapping](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site)
- [x] jekyll [theme](https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/adding-a-theme-to-your-github-pages-site-using-jekyll)
- [x] jekyll [`_config.yml`](https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/about-github-pages-and-jekyll#configuring-jekyll-in-your-github-pages-site)
- [x] (maybe) update `docs/404.md`
- [x] update `docs/index.md`
- [x] update headers and footers