### PR TITLE
Introduce Asset::ACTIVATE for registration of Assets in wp-activate.php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": ">=7.2",
         "ext-json": "*",
         "ext-dom": "*",
-        "inpsyde/wp-context": "^1"
+        "inpsyde/wp-context": "^1.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5",

--- a/docs/assets.md
+++ b/docs/assets.md
@@ -103,6 +103,7 @@ By default, the package comes with predefined locations of assets:
 |`Asset::CUSTOMIZER_PREVIEW`|`customize_preview_init`|Customizer Preview|
 |`Asset::BLOCK_EDITOR_ASSETS`|`enqueue_block_editor_assets`|Gutenberg Editor|
 |`Asset::BLOCK_ASSETS`|`enqueue_block_editor_assets`|Frontend and Gutenberg Editor|
+|`Asset::ACTIVATE`|`enqueue_block_editor_assets`|Frontend and Gutenberg Editor|
 
 #### API
 

--- a/docs/assets.md
+++ b/docs/assets.md
@@ -123,7 +123,7 @@ $style = new Style('foo', 'www.example.com/style.css');
 $style->forLocation(Asset::FRONTEND);
 ```
 
-The default location is `Asset::FRONTEND`.
+The default location is `Asset::FRONTEND | Asset::ACTIVATE`.
 
 #### Using multiple locations
 

--- a/src/Asset.php
+++ b/src/Asset.php
@@ -24,6 +24,7 @@ interface Asset
     public const BLOCK_EDITOR_ASSETS = 32;
     public const BLOCK_ASSETS = 64;
     public const CUSTOMIZER_PREVIEW = 128;
+    public const ACTIVATE = 256;
     // Hooks
     public const HOOK_FRONTEND = 'wp_enqueue_scripts';
     public const HOOK_BACKEND = 'admin_enqueue_scripts';
@@ -32,6 +33,7 @@ interface Asset
     public const HOOK_CUSTOMIZER_PREVIEW = 'customize_preview_init';
     public const HOOK_BLOCK_ASSETS = 'enqueue_block_assets';
     public const HOOK_BLOCK_EDITOR_ASSETS = 'enqueue_block_editor_assets';
+    public const HOOK_ACTIVATE = 'activate_wp_head';
     // Hooks to Locations map
     public const HOOK_TO_LOCATION = [
         Asset::HOOK_FRONTEND => Asset::FRONTEND,
@@ -41,6 +43,7 @@ interface Asset
         Asset::HOOK_CUSTOMIZER_PREVIEW => Asset::CUSTOMIZER_PREVIEW,
         Asset::HOOK_BLOCK_ASSETS => Asset::BLOCK_ASSETS,
         Asset::HOOK_BLOCK_EDITOR_ASSETS => Asset::BLOCK_EDITOR_ASSETS,
+        Asset::HOOK_ACTIVATE => Asset::HOOK_ACTIVATE,
     ];
 
     /**

--- a/src/Asset.php
+++ b/src/Asset.php
@@ -34,7 +34,10 @@ interface Asset
     public const HOOK_BLOCK_ASSETS = 'enqueue_block_assets';
     public const HOOK_BLOCK_EDITOR_ASSETS = 'enqueue_block_editor_assets';
     public const HOOK_ACTIVATE = 'activate_wp_head';
-    // Hooks to Locations map
+    /**
+     * Hooks to Locations map
+     * @var array<string,int>
+     */
     public const HOOK_TO_LOCATION = [
         Asset::HOOK_FRONTEND => Asset::FRONTEND,
         Asset::HOOK_BACKEND => Asset::BACKEND,

--- a/src/AssetManager.php
+++ b/src/AssetManager.php
@@ -248,6 +248,7 @@ final class AssetManager
             return [];
         }
 
+        /** @var int|null $locationId */
         $locationId = Asset::HOOK_TO_LOCATION[$currentHook] ?? null;
         if (!$locationId) {
             return [];

--- a/src/BaseAsset.php
+++ b/src/BaseAsset.php
@@ -107,7 +107,7 @@ abstract class BaseAsset implements Asset
     public function __construct(
         string $handle,
         string $url,
-        int $location = Asset::FRONTEND
+        int $location = Asset::FRONTEND | Asset::ACTIVATE
     ) {
 
         $this->handle = $handle;

--- a/src/Style.php
+++ b/src/Style.php
@@ -27,7 +27,7 @@ class Style extends BaseAsset implements Asset
     protected $media = 'all';
 
     /**
-     * @var array|null
+     * @var string[]|null
      */
     protected $inlineStyles = null;
 
@@ -52,7 +52,7 @@ class Style extends BaseAsset implements Asset
     }
 
     /**
-     * @return array
+     * @return string[]|null
      */
     public function inlineStyles(): ?array
     {

--- a/src/Util/AssetHookResolver.php
+++ b/src/Util/AssetHookResolver.php
@@ -18,7 +18,6 @@ use Inpsyde\Assets\Asset;
 
 class AssetHookResolver
 {
-
     /**
      * @var WpContext
      */
@@ -84,6 +83,8 @@ class AssetHookResolver
                 return Asset::HOOK_FRONTEND;
             case $this->context->isBackoffice():
                 return Asset::HOOK_BACKEND;
+            case $this->context->isWpActivate():
+                return Asset::HOOK_ACTIVATE;
         }
 
         return null;

--- a/src/Util/AssetHookResolver.php
+++ b/src/Util/AssetHookResolver.php
@@ -41,13 +41,18 @@ class AssetHookResolver
     {
         $isLogin = $this->context->isLogin();
         $isFront = $this->context->isFrontoffice();
+        $isActivate = $this->context->isWpActivate();
 
-        if (!$isLogin && !$isFront && !$this->context->isBackoffice()) {
+        if (!$isActivate && !$isLogin && !$isFront && !$this->context->isBackoffice()) {
             return [];
         }
 
         if ($isLogin) {
             return [Asset::HOOK_LOGIN];
+        }
+
+        if ($isActivate) {
+            return [Asset::HOOK_ACTIVATE];
         }
 
         // These hooks might be fired in both front and back office.

--- a/tests/phpunit/Unit/Asset/BaseAssetTest.php
+++ b/tests/phpunit/Unit/Asset/BaseAssetTest.php
@@ -54,7 +54,7 @@ class BaseAssetTest extends AbstractTestCase
         static::assertTrue($asset->enqueue());
         static::assertEmpty($asset->filters());
         static::assertEmpty($asset->data());
-        static::assertSame(Asset::FRONTEND, $asset->location());
+        static::assertSame(Asset::FRONTEND | Asset::ACTIVATE, $asset->location());
     }
 
     /**
@@ -167,7 +167,7 @@ class BaseAssetTest extends AbstractTestCase
     {
         $asset = $this->createBaseAsset();
 
-        static::assertSame(Asset::FRONTEND, $asset->location());
+        static::assertSame(Asset::FRONTEND | Asset::ACTIVATE, $asset->location());
 
         $asset->forLocation(Asset::BACKEND);
         static::assertSame(Asset::BACKEND, $asset->location());

--- a/tests/phpunit/Unit/Asset/ScriptTest.php
+++ b/tests/phpunit/Unit/Asset/ScriptTest.php
@@ -44,7 +44,7 @@ class ScriptTest extends AbstractTestCase
         static::assertTrue($script->inFooter());
         static::assertEmpty($script->localize());
         static::assertSame(ScriptHandler::class, $script->handler());
-        static::assertSame(Asset::FRONTEND, $script->location());
+        static::assertSame(Asset::FRONTEND | Asset::ACTIVATE, $script->location());
     }
 
     /**

--- a/tests/phpunit/Unit/Asset/StyleTest.php
+++ b/tests/phpunit/Unit/Asset/StyleTest.php
@@ -28,7 +28,7 @@ class StyleTest extends AbstractTestCase
 
         static::assertInstanceOf(Asset::class, $testee);
         static::assertSame('all', $testee->media());
-        static::assertSame(Asset::FRONTEND, $testee->location());
+        static::assertSame(Asset::FRONTEND | Asset::ACTIVATE, $testee->location());
         static::assertSame(StyleHandler::class, $testee->handler());
     }
 

--- a/tests/phpunit/Unit/Util/AssetHookResolverTest.php
+++ b/tests/phpunit/Unit/Util/AssetHookResolverTest.php
@@ -46,7 +46,18 @@ class AssetHookResolverTest extends AbstractTestCase
             static::assertSame([], $hookResolver->resolve());
         }
     }
+    /**
+     * @test
+     */
+    public function testResolveActivate(): void
+    {
+        $context = WpContext::new()->force(WpContext::WP_ACTIVATE);
+        $hookResolver = new AssetHookResolver($context);
 
+        static::assertSame([Asset::HOOK_ACTIVATE], $hookResolver->resolve());
+    }
+
+    /**
     /**
      * @test
      */

--- a/tests/phpunit/Unit/Util/AssetHookResolverTest.php
+++ b/tests/phpunit/Unit/Util/AssetHookResolverTest.php
@@ -20,7 +20,6 @@ use Inpsyde\WpContext;
 
 class AssetHookResolverTest extends AbstractTestCase
 {
-
     /**
      * @test
      */
@@ -46,6 +45,7 @@ class AssetHookResolverTest extends AbstractTestCase
             static::assertSame([], $hookResolver->resolve());
         }
     }
+
     /**
      * @test
      */
@@ -57,7 +57,6 @@ class AssetHookResolverTest extends AbstractTestCase
         static::assertSame([Asset::HOOK_ACTIVATE], $hookResolver->resolve());
     }
 
-    /**
     /**
      * @test
      */
@@ -100,5 +99,48 @@ class AssetHookResolverTest extends AbstractTestCase
             ],
             $hookResolver->resolve()
         );
+    }
+
+    /**
+     * @test
+     * @dataProvider provideLastHook
+     */
+    public function testResolveLastHook(string $currentContext, $expected): void
+    {
+        $context = WpContext::new()->force($currentContext);
+        $hookResolver = new AssetHookResolver($context);
+
+        static::assertSame(
+            $expected,
+            $hookResolver->lastHook()
+        );
+    }
+
+    public function provideLastHook(): \Generator
+    {
+        yield "not matching" => [
+            WpContext::AJAX,
+            null,
+        ];
+
+        yield "login" => [
+            WpContext::LOGIN,
+            Asset::HOOK_LOGIN,
+        ];
+
+        yield "frontend" => [
+            WpContext::FRONTOFFICE,
+            Asset::HOOK_FRONTEND,
+        ];
+
+        yield "backend" => [
+            WpContext::BACKOFFICE,
+            Asset::HOOK_BACKEND,
+        ];
+
+        yield "wp-activate.php" => [
+            WpContext::WP_ACTIVATE,
+            Asset::HOOK_ACTIVATE,
+        ];
     }
 }


### PR DESCRIPTION
see https://github.com/inpsyde/assets/issues/34

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

New `Asset::ACTIVATE` location to register and enqueue assets in `wp-activate.php`. Also bumping the `inpsyde/wp-context` version to min 1.3.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

no.