### PR TITLE
fix: change AssetHookResolver::$context visibility to make the class extendable

### DIFF
--- a/src/Util/AssetHookResolver.php
+++ b/src/Util/AssetHookResolver.php
@@ -21,7 +21,7 @@ class AssetHookResolver
     /**
      * @var WpContext
      */
-    private $context;
+    protected $context;
 
     /**
      * @param WpContext|null $context


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Using a private `$context` in the `AssetHookResolver` makes extending it really hard because you can't call `parent::resolve()` in the child class.

**What is the current behavior?** (You can also link to an open issue here)

```php
class CustomHookResolver extends AssetHookResolver
{
    public function resolve(): array
    {
        $assets = parent::resolve();
        if(!empty($assets)) {
            return $assets;
        }

        // Some custom code
        if ($this->context->isAjax()) {
            // Fails, $this->context is `null` 😢
        }
    }

}
```

**What is the new behavior (if this is a feature change)?**

```php
class CustomHookResolver extends AssetHookResolver
{
    public function resolve(): array
    {
        $assets = parent::resolve();
        if(!empty($assets)) {
            return $assets;
        }

        // Some custom code
        if ($this->context->isAjax()) {
            // Works! 😀
        }
    }

}
```

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

It might not.

