### PR TITLE
feat: add the ability to load selected entrypoints

### DIFF
--- a/docs/loaders.md
+++ b/docs/loaders.md
@@ -92,6 +92,53 @@ $third->dependencies(); // handles from $asset[1] and $asset[2]
 ```
 
 
+Since your `entrypoints.json` file can contain multiple entries, you can choose to load only some of them.
+
+```json
+{
+    "entrypoints": {
+         "theme": {
+             "css": [
+                 "./theme.css",
+                 "./theme1.css",
+                 "./theme2.css",
+             ]
+        },
+         "contact": {
+             "css": [
+                 "./contact.css",
+             ]
+        },
+         "editor": {
+             "css": [
+                 "./editor.css",
+             ]
+        }
+     }
+}
+```
+
+And loading this file:
+
+```php
+<?php
+use Inpsyde\Assets\Loader\EncoreEntrypointsLoader;
+
+$loader = new EncoreEntrypointsLoader();
+/** @var \Inpsyde\Assets\Asset[] $assets */
+$assets = $loader->load('entrypoints.json', ['theme', 'contact']);
+
+$second = $assets[1]; // theme1.css
+$second->dependencies(); // handle from $asset[0]
+
+$third = $assets[2]; // theme2.css
+$third->dependencies(); // handles from $asset[1] and $asset[2]
+```
+
+### `BudEntrypointsLoader`
+
+[Bud](https://bud.js.org/) also provides an `entrypoints.json` file and can be used with API as `EncoreEntrypointsLoader`.
+
 ## `ArrayLoader`
 
 To create multiple Assets you can use following:

--- a/src/Loader/AbstractWebpackLoader.php
+++ b/src/Loader/AbstractWebpackLoader.php
@@ -52,13 +52,14 @@ abstract class AbstractWebpackLoader implements LoaderInterface
 
     /**
      * @param mixed $resource
+     * @param array $entrypoints
      *
      * @return array
      *
      * phpcs:disable Inpsyde.CodeQuality.ArgumentTypeDeclaration
      * @psalm-suppress MixedArgument
      */
-    public function load($resource): array
+    public function load($resource, array $entrypoints = []): array
     {
         if (!is_string($resource) || !is_readable($resource)) {
             throw new FileNotFoundException(
@@ -79,7 +80,7 @@ abstract class AbstractWebpackLoader implements LoaderInterface
             );
         }
 
-        return $this->parseData($data, $resource);
+        return $this->parseData($data, $resource, $entrypoints);
     }
 
     /**

--- a/src/Loader/BudEntrypointsLoader.php
+++ b/src/Loader/BudEntrypointsLoader.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Assets package.
+ *
+ * (c) Inpsyde GmbH
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Inpsyde\Assets\Loader;
+
+class BudEntrypointsLoader extends EncoreEntrypointsLoader
+{
+    protected function parseData(array $data, string $resource, array $entrypoints = []): array
+    {
+        $directory = trailingslashit(dirname($resource));
+        /** @var array{css:string[], js:string[]} $data */
+        $data = is_array($data) ? $data : [];
+        if (!empty($entrypoints)) {
+            $data = array_filter($data, static function (string $handle) use ($entrypoints) {
+                return in_array($handle, $entrypoints, true);
+            }, ARRAY_FILTER_USE_KEY);
+        }
+
+        $assets = [];
+        foreach ($data as $handle => $filesByExtension) {
+            $files = $filesByExtension['css'] ?? [];
+            $assets = array_merge($assets, $this->extractAssets($handle, $files, $directory));
+
+            $files = $filesByExtension['js'] ?? [];
+            $assets = array_merge($assets, $this->extractAssets($handle, $files, $directory));
+        }
+
+        return $assets;
+    }
+}

--- a/src/Loader/EncoreEntrypointsLoader.php
+++ b/src/Loader/EncoreEntrypointsLoader.php
@@ -26,11 +26,16 @@ class EncoreEntrypointsLoader extends AbstractWebpackLoader implements LoaderInt
     /**
      * {@inheritDoc}
      */
-    protected function parseData(array $data, string $resource): array
+    protected function parseData(array $data, string $resource, array $entrypoints = []): array
     {
         $directory = trailingslashit(dirname($resource));
         /** @var array{entrypoints:array{css?:string[], js?:string[]}} $data */
         $data = $data['entrypoints'] ?? [];
+        if (!empty($entrypoints)) {
+            $data = array_filter($data, static function (string $handle) use ($entrypoints) {
+                return in_array($handle, $entrypoints, true);
+            }, ARRAY_FILTER_USE_KEY);
+        }
 
         $assets = [];
         foreach ($data as $handle => $filesByExtension) {

--- a/tests/phpunit/Unit/Loader/AbstractWebpackLoaderTest.php
+++ b/tests/phpunit/Unit/Loader/AbstractWebpackLoaderTest.php
@@ -50,7 +50,7 @@ class AbstractWebpackLoaderTest extends AbstractTestCase
                 return [];
             }
 
-            public function load($filePath): array
+            public function load($filePath, array $entrypoints = []): array
             {
                 return parent::load($filePath);
             }
@@ -77,7 +77,7 @@ class AbstractWebpackLoaderTest extends AbstractTestCase
                 return [];
             }
 
-            public function load($filePath): array
+            public function load($filePath, array $entrypoints = []): array
             {
                 return parent::load($filePath);
             }

--- a/tests/phpunit/Unit/Loader/BudEntrypointsLoaderTest.php
+++ b/tests/phpunit/Unit/Loader/BudEntrypointsLoaderTest.php
@@ -14,14 +14,14 @@ declare(strict_types=1);
 namespace Inpsyde\Assets\Tests\Unit\Loader;
 
 use Inpsyde\Assets\Asset;
-use Inpsyde\Assets\Loader\EncoreEntrypointsLoader;
+use Inpsyde\Assets\Loader\BudEntrypointsLoader;
 use Inpsyde\Assets\Script;
 use Inpsyde\Assets\Style;
 use Inpsyde\Assets\Tests\Unit\AbstractTestCase;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
 
-class EncoreEntrypointsLoaderTest extends AbstractTestCase
+class BudEntrypointsLoaderTest extends AbstractTestCase
 {
     /**
      * @var  vfsStreamDirectory
@@ -39,18 +39,16 @@ class EncoreEntrypointsLoaderTest extends AbstractTestCase
      */
     public function testLoad()
     {
-        $testee = new EncoreEntrypointsLoader();
+        $testee = new BudEntrypointsLoader();
 
         $file = $this->mockEntrypointsFile(
             [
-                "entrypoints" => [
-                    "theme" => [
-                        "css" => [
-                            "./theme.css",
-                        ],
-                        "js" => [
-                            "./theme.js",
-                        ],
+                "theme" => [
+                    "css" => [
+                        "./theme.css",
+                    ],
+                    "js" => [
+                        "./theme.js",
                     ],
                 ],
             ]
@@ -68,31 +66,29 @@ class EncoreEntrypointsLoaderTest extends AbstractTestCase
      */
     public function testLoadSelectedEntrypoints(): void
     {
-        $testee = new EncoreEntrypointsLoader();
+        $testee = new BudEntrypointsLoader();
 
         $file = $this->mockEntrypointsFile(
             [
-                "entrypoints" => [
-                    "theme" => [
-                        "css" => [
-                            "./theme.css",
-                        ],
-                        "js" => [
-                            "./theme.js",
-                        ],
+                "theme" => [
+                    "css" => [
+                        "./theme.css",
                     ],
-                    "contact" => [
-                        "css" => [
-                            "./contact.css",
-                        ],
+                    "js" => [
+                        "./theme.js",
                     ],
-                    "editor" => [
-                        "css" => [
-                            "./editor.css",
-                        ],
-                        "js" => [
-                            "./editor.js",
-                        ],
+                ],
+                "contact" => [
+                    "css" => [
+                        "./contact.css",
+                    ],
+                ],
+                "editor" => [
+                    "css" => [
+                        "./editor.css",
+                    ],
+                    "js" => [
+                        "./editor.js",
                     ],
                 ],
             ]
@@ -111,17 +107,15 @@ class EncoreEntrypointsLoaderTest extends AbstractTestCase
      */
     public function testLoadWithDependencies()
     {
-        $testee = new EncoreEntrypointsLoader();
+        $testee = new BudEntrypointsLoader();
 
         $file = $this->mockEntrypointsFile(
             [
-                "entrypoints" => [
-                    "theme" => [
-                        "css" => [
-                            "./theme.css",
-                            "./theme1.css",
-                            "./theme2.css",
-                        ],
+                "theme" => [
+                    "css" => [
+                        "./theme.css",
+                        "./theme1.css",
+                        "./theme2.css",
                     ],
                 ],
             ]


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

- Add the ability to load a selected entrypoints
- Add BudEntrypointsLoader


**What is the current behavior?** (You can also link to an open issue here)

The `EncoreEntrypointsLoader` actually loads all assets found in `entrypoints.json` but this might result in loading non wanted assets if you don't (or can't) adhere to the [location resolver naming convention](https://github.com/inpsyde/assets/blob/f99dccf3316bec3add2118e0776e2802d2f23282/src/Loader/AbstractWebpackLoader.php#L184-L207).

**What is the new behavior (if this is a feature change)?**

Add an `(array) $entrypoints` parameter to the `load` method so you can manually set the desired entrypoints.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

The `Loader` interface remains unchanged so this should not.

**Other information**:

I also added a `BudEntrypointsLoader` which is basically similar to `EncoreEntrypointsLoader` besides it does not have an `entrypoints` key.