### PR TITLE
Fix/rename inpsyde to syde

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,13 @@ Assets is a Composer package (not a WordPress plugin) that allows to deal with s
 
 ## Installation
 
-```
+```bash
 $ composer require inpsyde/assets
 ```
 
-
 ## Minimum Requirements and Dependencies
 
-* PHP 7+
+* PHP 7.2+
 * WordPress latest-2
 
 When installed for development via Composer, Assets also requires:
@@ -29,7 +28,6 @@ When installed for development via Composer, Assets also requires:
 * brain/monkey (MIT)
 * inpsyde/php-coding-standards
 
-
 ## Documentation
 
 Please refer to [/docs](./docs) or https://inpsyde.github.io/assets for information.
@@ -37,3 +35,7 @@ Please refer to [/docs](./docs) or https://inpsyde.github.io/assets for informat
 ## License and Copyright
 
 This repository is a free software, and is released under the terms of the GNU General Public License version 2 or (at your option) any later version. See [LICENSE](./LICENSE) for complete license.
+
+Copyright (c) Syde GmbH.
+
+The team at [Syde](https://syde.com) is engineering the Web since 2006.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Inpsyde Assets
+# Assets
 
 [![Version](https://img.shields.io/packagist/v/inpsyde/assets.svg)](https://packagist.org/packages/inpsyde/assets)
 [![Status](https://img.shields.io/badge/status-active-brightgreen.svg)](https://github.com/inpsyde/assets)
@@ -9,7 +9,7 @@
 
 
 ## Introduction
-Inpsyde Assets is a Composer package (not a WordPress plugin) that allows to deal with scripts and styles in a WordPress site.
+Assets is a Composer package (not a WordPress plugin) that allows to deal with scripts and styles in a WordPress site.
 
 ## Installation
 
@@ -23,7 +23,7 @@ $ composer require inpsyde/assets
 * PHP 7+
 * WordPress latest-2
 
-When installed for development, via Composer, Inpsyde Assets also requires:
+When installed for development via Composer, Assets also requires:
 
 * phpunit/phpunit (BSD-3-Clause)
 * brain/monkey (MIT)

--- a/composer.json
+++ b/composer.json
@@ -5,14 +5,14 @@
     "license": "GPL-2.0-or-later",
     "authors": [
         {
-            "name": "Inpsyde",
-            "email": "hello@inpsyde.com",
-            "homepage": "https://inpsyde.com",
+            "name": "Syde",
+            "email": "hello@syde.com",
+            "homepage": "https://syde.com",
             "role": "Company"
         },
         {
             "name": "Christian Leucht",
-            "email": "c.leucht@inpsyde.com",
+            "email": "c.leucht@syde.com",
             "homepage": "https://www.chrico.info",
             "role": "Developer"
         }

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,10 +4,10 @@ nav_order: 0
 permalink: /
 ---
 
-# Inpsyde Assets
+# Assets
 
 ## Introduction
-Inpsyde Assets is a Composer package (not a plugin) that allows to deal with scripts and styles in a WordPress site.
+Assets is a Composer package (not a WordPress plugin) that allows to deal with scripts and styles in a WordPress site.
 
 ## Installation
 
@@ -20,7 +20,7 @@ $ composer require inpsyde/assets
 * PHP 7.2+
 * WordPress latest-2
 
-When installed for development, via Composer, Inpsyde Assets also requires:
+When installed for development via Composer, Assets also requires:
 
 * phpunit/phpunit (BSD-3-Clause)
 * brain/monkey (MIT)
@@ -28,6 +28,8 @@ When installed for development, via Composer, Inpsyde Assets also requires:
 
 ## License and Copyright
 
-Copyright (c) Inpsyde GmbH.
+This repository is a free software, and is released under the terms of the GNU General Public License version 2 or (at your option) any later version. See [LICENSE](./LICENSE) for complete license.
 
-The team at [Inpsyde](https://inpsyde.com) is engineering the Web since 2006.
+Copyright (c) Syde GmbH.
+
+The team at [Syde](https://syde.com) is engineering the Web since 2006.


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This is a docs update and a change to Composer properties that refer to Inpsyde

**What is the current behavior?** (You can also link to an open issue here)
- The package is named "Inpsyde Assets"
-  The README.md and composer.json files contain references to Inpsyde
-  The contents of the root-level README diverge from the README file in /docs that serves our GitHub pages homepage.

**What is the new behavior (if this is a feature change)?**
- The package is named "Assets"
- The README.md and composer.json files now refer to Syde
- The content of the README files is in sync.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
N/A