### PR TITLE
PHP 8.4: Implicitly marking parameter as nullable is deprecated

### DIFF
--- a/src/AssetManager.php
+++ b/src/AssetManager.php
@@ -55,7 +55,7 @@ final class AssetManager
     /**
      * @param AssetHookResolver|null $hookResolver
      */
-    public function __construct(AssetHookResolver $hookResolver = null)
+    public function __construct(?AssetHookResolver $hookResolver = null)
     {
         $this->hookResolver = $hookResolver ?? new AssetHookResolver();
         $this->assets = new \SplObjectStorage();

--- a/src/Script.php
+++ b/src/Script.php
@@ -155,7 +155,7 @@ class Script extends BaseAsset implements Asset
      *
      * @return static
      */
-    public function withTranslation(string $domain = 'default', string $path = null): Script
+    public function withTranslation(string $domain = 'default', ?string $path = null): Script
     {
         $this->translation = ['domain' => $domain, 'path' => $path];
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Fixes a PHP Warning in PHP 8.4: `Implicitly marking parameter as nullable is deprecated, the explicit nullable type must be used instead`.

**Does this PR introduce a breaking change?** 
No, the minimum of this project is 7.2, nullable types were introduced in PHP 7.1.