### PR TITLE
Fix `Asset::BLOCK_ASSETS` hook in documentation

### DIFF
--- a/docs/assets.md
+++ b/docs/assets.md
@@ -94,16 +94,16 @@ By default Assets are always enqueued.
 
 By default, the package comes with predefined locations of assets:
 
-|const|hook|location|
-|---|---|---|
-|`Asset::FRONTEND`|`wp_enqueue_scripts`|Frontend|
-|`Asset::BACKEND`|`admin_enqueue_scripts`|Backend|
-|`Asset::LOGIN`|`login_enqueue_scripts`|wp-login.php|
-|`Asset::CUSTOMIZER`|`customize_controls_enqueue_scripts`|Customizer|
-|`Asset::CUSTOMIZER_PREVIEW`|`customize_preview_init`|Customizer Preview|
-|`Asset::BLOCK_EDITOR_ASSETS`|`enqueue_block_editor_assets`|Gutenberg Editor|
-|`Asset::BLOCK_ASSETS`|`enqueue_block_assets`|Frontend and Gutenberg Editor|
-|`Asset::ACTIVATE`|`activate_wp_head`|wp-activate.php|
+| const                        | hook                                                                                                                        | location                      |
+|------------------------------|-----------------------------------------------------------------------------------------------------------------------------|-------------------------------|
+| `Asset::FRONTEND`            | [`wp_enqueue_scripts`](https://developer.wordpress.org/reference/hooks/wp_enqueue_scripts/)                                 | Frontend                      |
+| `Asset::BACKEND`             | [`admin_enqueue_scripts`](https://developer.wordpress.org/reference/hooks/admin_enqueue_scripts/)                           | Backend                       |
+| `Asset::LOGIN`               | [`login_enqueue_scripts`](https://developer.wordpress.org/reference/hooks/login_enqueue_scripts/)                           | wp-login.php                  |
+| `Asset::CUSTOMIZER`          | [`customize_controls_enqueue_scripts`](https://developer.wordpress.org/reference/hooks/customize_controls_enqueue_scripts/) | Customizer                    |
+| `Asset::CUSTOMIZER_PREVIEW`  | [`customize_preview_init`](https://developer.wordpress.org/reference/hooks/customize_preview_init/)                         | Customizer Preview            |
+| `Asset::BLOCK_EDITOR_ASSETS` | [`enqueue_block_editor_assets`](https://developer.wordpress.org/reference/hooks/enqueue_block_editor_assets/)               | Gutenberg Editor              |
+| `Asset::BLOCK_ASSETS`        | [`enqueue_block_assets`](https://developer.wordpress.org/reference/hooks/enqueue_block_assets/)                             | Frontend and Gutenberg Editor |
+| `Asset::ACTIVATE`            | [`activate_wp_head`](https://developer.wordpress.org/reference/hooks/activate_wp_head/)                                     | wp-activate.php               |
 
 #### API
 

--- a/docs/assets.md
+++ b/docs/assets.md
@@ -102,7 +102,7 @@ By default, the package comes with predefined locations of assets:
 |`Asset::CUSTOMIZER`|`customize_controls_enqueue_scripts`|Customizer|
 |`Asset::CUSTOMIZER_PREVIEW`|`customize_preview_init`|Customizer Preview|
 |`Asset::BLOCK_EDITOR_ASSETS`|`enqueue_block_editor_assets`|Gutenberg Editor|
-|`Asset::BLOCK_ASSETS`|`enqueue_block_editor_assets`|Frontend and Gutenberg Editor|
+|`Asset::BLOCK_ASSETS`|`enqueue_block_assets`|Frontend and Gutenberg Editor|
 |`Asset::ACTIVATE`|`activate_wp_head`|wp-activate.php|
 
 #### API


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bugfix


**What is the current behavior?** (You can also link to an open issue here)
`Asset::BLOCK_ASSETS` is incorrectly assigned to the `enqueue_block_editor_assets` hook in the documentation.


**What is the new behavior (if this is a feature change)?**
`Asset::BLOCK_ASSETS` is correctly assigned to the `enqueue_block_assets ` hook in the documentation.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
I added links to the WordPress Developer Resources for all hooks according to the Boy Scout rule; the actual fix is [`0414a0a` (#61)](https://github.com/inpsyde/assets/pull/61/commits/0414a0a78f05dc793741e5561a827f0db8e0ff47).