### PR TITLE
feat: Add an optional `disableDependencyExtraction()` method

### DIFF
--- a/src/Script.php
+++ b/src/Script.php
@@ -35,6 +35,19 @@ class Script extends BaseAsset implements Asset, DataAwareAsset, FilterAwareAsse
         'path' => null,
     ];
 
+    protected bool $dependencyExtractionEnabled = false;
+
+    public function __construct(
+        string $handle,
+        string $url,
+        int $location = Asset::FRONTEND | Asset::ACTIVATE,
+        bool $dependencyExtractionEnabled = true
+    ) {
+
+        parent::__construct($handle, $url, $location);
+        $this->dependencyExtractionEnabled = $dependencyExtractionEnabled;
+    }
+
     /**
      * @return array<string, mixed>
      */
@@ -199,7 +212,7 @@ class Script extends BaseAsset implements Asset, DataAwareAsset, FilterAwareAsse
      */
     public function version(): ?string
     {
-        $this->resolveDependencyExtractionPlugin();
+        $this->dependencyExtractionEnabled and $this->resolveDependencyExtractionPlugin();
 
         return parent::version();
     }
@@ -209,7 +222,7 @@ class Script extends BaseAsset implements Asset, DataAwareAsset, FilterAwareAsse
      */
     public function dependencies(): array
     {
-        $this->resolveDependencyExtractionPlugin();
+        $this->dependencyExtractionEnabled and $this->resolveDependencyExtractionPlugin();
 
         return parent::dependencies();
     }

--- a/src/ScriptModule.php
+++ b/src/ScriptModule.php
@@ -15,6 +15,19 @@ class ScriptModule extends BaseAsset implements Asset
      */
     protected array $data = [];
 
+    protected bool $dependencyExtractionEnabled = false;
+
+    public function __construct(
+        string $handle,
+        string $url,
+        int $location = Asset::FRONTEND | Asset::ACTIVATE,
+        bool $dependencyExtractionEnabled = true
+    ) {
+
+        parent::__construct($handle, $url, $location);
+        $this->dependencyExtractionEnabled = $dependencyExtractionEnabled;
+    }
+
     /**
      * @return array<string, mixed>
      */
@@ -48,7 +61,7 @@ class ScriptModule extends BaseAsset implements Asset
      */
     public function version(): ?string
     {
-        $this->resolveDependencyExtractionPlugin();
+        $this->dependencyExtractionEnabled and $this->resolveDependencyExtractionPlugin();
 
         return parent::version();
     }
@@ -58,7 +71,7 @@ class ScriptModule extends BaseAsset implements Asset
      */
     public function dependencies(): array
     {
-        $this->resolveDependencyExtractionPlugin();
+        $this->dependencyExtractionEnabled and $this->resolveDependencyExtractionPlugin();
 
         return parent::dependencies();
     }

--- a/tests/phpunit/Unit/Asset/ScriptModuleTest.php
+++ b/tests/phpunit/Unit/Asset/ScriptModuleTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Inpsyde\Assets\Tests\Unit\Asset;
+
+use Inpsyde\Assets\Asset;
+use Inpsyde\Assets\Handler\ScriptModuleHandler;
+use Inpsyde\Assets\ScriptModule;
+use Inpsyde\Assets\Tests\Unit\AbstractTestCase;
+use org\bovigo\vfs\vfsStream;
+
+class ScriptModuleTest extends AbstractTestCase
+{
+    /**
+     * @var \org\bovigo\vfs\vfsStreamDirectory
+     */
+    private $root;
+
+    public function setUp(): void
+    {
+        $this->root = vfsStream::setup('tmp');
+        parent::setUp();
+    }
+
+    /**
+     * @test
+     */
+    public function testBasic(): void
+    {
+        $scriptModule = new ScriptModule('foo', 'foo.js');
+
+        static::assertSame(ScriptModuleHandler::class, $scriptModule->handler());
+        static::assertSame(Asset::FRONTEND | Asset::ACTIVATE, $scriptModule->location());
+    }
+
+    /**
+     * @test
+     */
+    public function testWithData(): void
+    {
+        $scriptModule = new ScriptModule('handle', 'script.js');
+
+        static::assertEmpty($scriptModule->data());
+
+        $expectedData = ['foo' => 'bar', 'baz' => 'qux'];
+        $scriptModule->withData($expectedData);
+
+        static::assertSame($expectedData, $scriptModule->data());
+    }
+
+    /**
+     * @test
+     */
+    public function testDependencyExtractionCanBeDisabled(): void
+    {
+        $expectedDependencies = ['foo', 'bar', 'baz'];
+        $expectedVersion = '1.0';
+
+        vfsStream::newFile('script.asset.json')
+            ->withContent(
+                json_encode(
+                    [
+                        'dependencies' => $expectedDependencies,
+                        'version' => $expectedVersion,
+                    ]
+                )
+            )
+            ->at($this->root);
+
+        $expectedFile = vfsStream::newFile('script.js')->at($this->root);
+
+        $testee = new ScriptModule('script', $expectedFile->url(), Asset::FRONTEND, false);
+        $testee->withFilePath($expectedFile->url());
+
+        // Dependencies should not be loaded from the .asset.json file
+        static::assertEmpty($testee->dependencies());
+
+        // Version is still autodiscovered from file modification time, not from .asset.json
+        // To verify it's not from .asset.json, we check it's not the expected version
+        static::assertNotEquals($expectedVersion, $testee->version());
+    }
+
+    /**
+     * @test
+     */
+    public function testDependencyExtractionEnabledByDefault(): void
+    {
+        $expectedDependencies = ['foo', 'bar', 'baz'];
+
+        vfsStream::newFile('script.asset.json')
+            ->withContent(json_encode(['dependencies' => $expectedDependencies]))
+            ->at($this->root);
+
+        $expectedFile = vfsStream::newFile('script.js')->at($this->root);
+
+        $testee = new ScriptModule('script', $expectedFile->url());
+        $testee->withFilePath($expectedFile->url());
+
+        // Should load dependencies by default
+        static::assertEqualsCanonicalizing(
+            $expectedDependencies,
+            $testee->dependencies()
+        );
+    }
+}


### PR DESCRIPTION
## Please check if the PR fulfills these requirements
- [ ] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Adds ability to disable automatic dependency extraction file lookups

## What is the current behavior? (You can also link to an open issue here)

Dependency extraction always performs I/O operations (DirectoryIterator scans, file reads) to search for .asset.json/.asset.php files, even when not needed. Which can lead to (minor) performance issues.

##  What is the new behavior (if this is a feature change)?

Users can disable dependency extraction lookups for better performance when manually managing dependencies:

```php
$script->disableDependencyExtraction();
```

##  Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. Dependency extraction remains enabled by default. This is an opt-in performance optimization.

I'll update the docs if you're ok with that change. 