### PR TITLE
fix: Attributes not applied when multipe `<script>` tags

### DIFF
--- a/src/OutputFilter/AttributesOutputFilter.php
+++ b/src/OutputFilter/AttributesOutputFilter.php
@@ -19,11 +19,11 @@ class AttributesOutputFilter implements AssetOutputFilter
 
         // Only extend <script> elements with "src" attribute
         // and don't extend inline <script></script> before and after.
-        if (
-            $tags->next_tag(['tag_name' => 'script'])
-            && (string) $tags->get_attribute('src')
-        ) {
-            $this->applyAttributes($tags, $attributes);
+        while ($tags->next_tag(['tag_name' => 'script'])) {
+            if ((string) $tags->get_attribute('src')) {
+                $this->applyAttributes($tags, $attributes);
+                break;
+            }
         }
 
         return $tags->get_updated_html();

--- a/tests/phpunit/Unit/OutputFilter/AttributesOutputFilterTest.php
+++ b/tests/phpunit/Unit/OutputFilter/AttributesOutputFilterTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Inpsyde\Assets\Tests\Unit\OutputFilter;
+
+use Brain\Monkey;
+use Inpsyde\Assets\FilterAwareAsset;
+use Inpsyde\Assets\OutputFilter\AssetOutputFilter;
+use Inpsyde\Assets\OutputFilter\AttributesOutputFilter;
+use Inpsyde\Assets\Tests\Unit\AbstractTestCase;
+
+class AttributesOutputFilterTest extends AbstractTestCase
+{
+    /**
+     * @test
+     */
+    public function testBasic()
+    {
+        static::assertInstanceOf(AssetOutputFilter::class, new AttributesOutputFilter());
+    }
+
+    /**
+     * @test
+     */
+    public function testRender()
+    {
+        $testee = new AttributesOutputFilter();
+
+        $expectedUrl = 'foo.js';
+        $input = '<script src="' . $expectedUrl . '"></script>';
+
+        Monkey\Functions\when('esc_attr')->returnArg(1);
+        Monkey\Functions\when('wp_kses_uri_attributes')->justReturn(['href', 'src', 'action']);
+
+        $stub = \Mockery::mock(FilterAwareAsset::class);
+        $stub->expects('attributes')->once()->andReturn([
+            'type' => 'module',
+        ]);
+
+        $output = $testee($input, $stub);
+
+        static::assertStringContainsString('type="module"', $output);
+        static::assertStringContainsString('src="' . $expectedUrl . '"', $output);
+    }
+
+    /**
+     * @test
+     */
+    public function testAttributesAppliedWithPrependedInlineScript()
+    {
+        $testee = new AttributesOutputFilter();
+
+        $expectedUrl = 'foo.js';
+        // Simulates WordPress output when prependInlineScript is used:
+        // inline script appears BEFORE the main script tag
+        $input = '<script>const foo = "bar";</script>'
+            . '<script src="' . $expectedUrl . '"></script>';
+
+        Monkey\Functions\when('esc_attr')->returnArg(1);
+        Monkey\Functions\when('wp_kses_uri_attributes')->justReturn(['href', 'src', 'action']);
+
+        $stub = \Mockery::mock(FilterAwareAsset::class);
+        $stub->expects('attributes')->once()->andReturn([
+            'defer' => true,
+        ]);
+
+        $output = $testee($input, $stub);
+
+        // The defer attribute should be applied to the script with src
+        static::assertStringContainsString('defer="defer"', $output);
+        static::assertStringContainsString('src="' . $expectedUrl . '"', $output);
+    }
+}

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -27,4 +27,11 @@ if (!defined('PHPUNIT_COMPOSER_INSTALL')) {
 defined('ABSPATH') or define('ABSPATH', "{$vendorDir}/johnpbloch/wordpress-core/");
 require_once "{$vendorDir}/johnpbloch/wordpress-core/wp-includes/class-wp-error.php";
 
+// Load HTML API dependencies (order matters)
+require_once "{$vendorDir}/johnpbloch/wordpress-core/wp-includes/html-api/class-wp-html-attribute-token.php";
+require_once "{$vendorDir}/johnpbloch/wordpress-core/wp-includes/html-api/class-wp-html-span.php";
+require_once "{$vendorDir}/johnpbloch/wordpress-core/wp-includes/html-api/class-wp-html-text-replacement.php";
+require_once "{$vendorDir}/johnpbloch/wordpress-core/wp-includes/html-api/class-wp-html-decoder.php";
+require_once "{$vendorDir}/johnpbloch/wordpress-core/wp-includes/html-api/class-wp-html-tag-processor.php";
+
 unset($testsDir, $libDir, $vendorDir, $autoload);


### PR DESCRIPTION
## Please check if the PR fulfills these requirements
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Bug fix

## What is the current behavior? (You can also link to an open issue here)

When using `prependInlineScript()` together with `withAttributes()`, the attributes are not applied to the script tag. This happens because `AttributesOutputFilter` only checks the first `<script>` tag, which is the inline script without a `src` attribute.

## What is the new behavior (if this is a feature change)?

Attributes are now correctly applied to the script tag with `src`, even when inline scripts are prepended before it.

## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No


## Other information

The fix changes the `if` statement to a `while` loop in `AttributesOutputFilter::__invoke()` to iterate through all `<script>` tags until finding one with a `src` attribute.